### PR TITLE
Add experimental 18i8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ Package.resolved
 *.xcodeproj
 .DS_Store
 
+reference/
+
 # Output of scripts/make-app.sh — the assembled .app bundle.  Rebuild
 # locally with the script; don't track binaries in git.
 build/
+

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ For dev iteration without packaging: `swift run scarlett-app`. There's also a `s
 | Scarlett 6i6 _(1st gen)_     | 🟡 &nbsp; Detected, support pending                  |
 | Scarlett 16i8 _(1st gen)_    | 🟡 &nbsp; Detected, support pending                  |
 | Scarlett 18i6 _(1st gen)_    | 🟡 &nbsp; Detected, support pending                  |
-| Scarlett 18i8 _(1st gen)_    | 🟡 &nbsp; Detected, support pending                  |
+| Scarlett 18i8 _(1st gen)_    | 🧪 &nbsp; Experimental                               |
 | Scarlett 18i20 _(1st gen)_   | 🟡 &nbsp; Detected, support pending                  |
 | Scarlett 2nd / 3rd / 4th gen | ❌ &nbsp; Different protocol — won't work            |
 | Saffire (FireWire) family    | ❌ &nbsp; Different transport — won't work           |
 
-> 🟡 The app will _recognise_ other 1st-gen Scarletts on the bus and show a friendly "not yet supported" screen — it won't try to drive them with the wrong byte tables.
+> 🧪 18i8 has _experimental_ support — the matrix mixer, routing, and most DSP controls work, but hasn't been battle-tested the way 8i6 has. Other 1st-gen Scarletts (6i6, 16i8, 18i6, 18i20) still show a friendly "not yet supported" screen.
 
 <br/>
 

--- a/Sources/ScarlettApp/App.swift
+++ b/Sources/ScarlettApp/App.swift
@@ -45,7 +45,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Approximate Apple's standard Dock icon look:
+        /// Approximate Apple's standard Dock icon look:
     ///  - inset the source artwork ~10% so the rendered icon matches the
     ///    visual size of stock macOS apps
     ///  - clip the whole canvas with a rounded rectangle (~22% corner
@@ -86,6 +86,11 @@ struct ScarlettApp: App {
                     idealHeight: 720,
                     maxHeight: .infinity
                 )
+                .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+                    if UserDefaults.standard.bool(forKey: "scarlett.autoBackupOnQuit") {
+                        state.userAutoSaveBackup(label: "at shutdown")
+                    }
+                }
         }
         .windowResizability(.contentSize)
         .commands {
@@ -115,7 +120,7 @@ private func exportSnapshot(state: MixerState) {
     // mangles our `.8i6` extension into "ScarlettSnapshot.8i6.json".
     panel.allowsOtherFileTypes = true
     panel.nameFieldStringValue = "ScarlettSnapshot.8i6"
-    panel.title = "Save Scarlett 8i6 snapshot"
+    panel.title = "Save Scarlett snapshot"
     if panel.runModal() == .OK, let url = panel.url {
         do { try state.userExportSnapshot(to: url) }
         catch {
@@ -130,7 +135,7 @@ private func importSnapshot(state: MixerState) {
     // No content-type filter — the user might have a `.8i6` file or a
     // `.json` file (both are valid, contents are checked at decode time).
     panel.allowsMultipleSelection = false
-    panel.title = "Open Scarlett 8i6 snapshot"
+    panel.title = "Open Scarlett snapshot"
     if panel.runModal() == .OK, let url = panel.url {
         do { try state.userImportSnapshot(from: url) }
         catch {

--- a/Sources/ScarlettApp/ChannelStrip.swift
+++ b/Sources/ScarlettApp/ChannelStrip.swift
@@ -30,7 +30,7 @@ struct ChannelStrip: View {
                 .frame(height: StripLayout.controlsHeight)
         }
         .frame(width: StripLayout.width)
-        .padding(.vertical, 10)
+        .padding(.vertical, 6)
         .padding(.horizontal, 6)
         .background(Theme.panel)
         .clipShape(RoundedRectangle(cornerRadius: 6))
@@ -49,53 +49,61 @@ struct ChannelStrip: View {
     // the same vertical space (an empty placeholder) to keep strip heights
     // consistent across the row.
 
-    @ViewBuilder
-    private func inputSwitch(source: SignalSource) -> some View {
-        switch source {
-        case .analog1:
-            ImpedanceSwitch(value: Binding(
-                get: { state.impedance1 },
-                set: { state.userSetImpedance(channel: 1, mode: $0) }
-            ))
-        case .analog2:
-            ImpedanceSwitch(value: Binding(
-                get: { state.impedance2 },
-                set: { state.userSetImpedance(channel: 2, mode: $0) }
-            ))
-        case .analog3:
-            HiLoSwitch(value: Binding(
-                get: { state.hi3 },
-                set: { state.userSetHiLo(channel: 3, hi: $0) }
-            ))
-        case .analog4:
-            HiLoSwitch(value: Binding(
-                get: { state.hi4 },
-                set: { state.userSetHiLo(channel: 4, hi: $0) }
-            ))
-        default:
-            // Reserve the same vertical footprint so every strip aligns.
-            Color.clear.frame(height: 22)
+    private func inputSwitch(source byte: UInt8) -> some View {
+        let profile = state.device?.profile ?? .scarlett8i6
+        let analogSources = profile.sources.filter { $0.category == .analog }
+        guard let analogIdx = analogSources.firstIndex(where: { $0.byte == byte }) else {
+            return AnyView(Color.clear.frame(height: StripLayout.switchRowHeight))
         }
+        let hwChannel = analogIdx + 1
+        if profile.impedanceChannels.contains(hwChannel) {
+            return AnyView(ImpedanceSwitch(value: Binding(
+                get: { hwChannel == 1 ? state.impedance1 : state.impedance2 },
+                set: { state.userSetImpedance(channel: hwChannel, mode: $0) }
+            )))
+        }
+        if profile.hiLoChannels.contains(hwChannel) {
+            return AnyView(HiLoSwitch(value: Binding(
+                get: { hwChannel == 3 ? state.hi3 : state.hi4 },
+                set: { state.userSetHiLo(channel: hwChannel, hi: $0) }
+            )))
+        }
+        return AnyView(Color.clear.frame(height: StripLayout.switchRowHeight))
     }
 
     // MARK: - Header
 
-    private func header(source: SignalSource) -> some View {
+    @ViewBuilder
+    private func header(source byte: UInt8) -> some View {
+        let profile = state.device?.profile ?? .scarlett8i6
+        let options = profile.matrixChannelSources
+        let current = options.first(where: { $0.byte == byte })
+            ?? profile.source(forByte: byte)
         VStack(spacing: 3) {
             nameField
             ThemedMenuPicker(
-                options: SignalSource.availableOn8i6,
+                options: options,
                 displayName: { $0.displayName },
                 selection: Binding(
-                    get: { state.mixerSources[channel] },
-                    set: { state.userSetMixerSource(channel: channel, source: $0) }
+                    get: { current },
+                    set: { state.userSetMixerSource(channel: channel, sourceByte: $0.byte) }
                 )
             )
-
             Rectangle()
-                .fill(source.accentColor)
+                .fill(accentColor(forByte: byte, from: profile))
                 .frame(height: 2)
                 .padding(.horizontal, 2)
+        }
+    }
+
+    private func accentColor(forByte byte: UInt8, from profile: DeviceProfile) -> Color {
+        guard let sd = profile.sources.first(where: { $0.byte == byte }) else {
+            return Theme.accentOther
+        }
+        switch sd.category {
+        case .analog, .digital: return Theme.accentAnalog
+        case .daw:              return Theme.accentPlayback
+        case .mixOutput, .off:  return Theme.accentOther
         }
     }
 
@@ -143,7 +151,7 @@ struct ChannelStrip: View {
     // MARK: - Fader column
 
     private var fader: some View {
-        let pair = MixerState.pairIndex(of: state.selectedBus)
+        let pair = state.selectedBusIndex / 2
         let level = state.mixerLevels[channel][pair]
         let source = state.mixerSources[channel]
 
@@ -162,11 +170,11 @@ struct ChannelStrip: View {
             // Reads peaks/peaksHeld/peaksMax internally → isolated from the
             // outer strip body so 20 Hz meter updates only re-render this
             // small view, not the whole strip (faders, pickers, buttons, …).
-            StripMeter(state: state, source: source)
+            StripMeter(state: state, sourceByte: source)
 
             DbScale()
         }
-        .frame(height: 220)
+        .frame(height: StripLayout.faderHeight)
         .overlay(alignment: .topTrailing) {
             Text(formatDb(level))
                 .font(.system(size: 9, design: .monospaced))
@@ -176,7 +184,7 @@ struct ChannelStrip: View {
     }
 
     private var panSlider: some View {
-        let pair = MixerState.pairIndex(of: state.selectedBus)
+        let pair = state.selectedBusIndex / 2
         let pan = state.mixerPans[channel][pair]
         return VStack(spacing: 1) {
             Slider(
@@ -206,7 +214,7 @@ struct ChannelStrip: View {
 
     private var peakReadout: some View {
         let source = state.mixerSources[channel]
-        return StripPeakReadout(state: state, source: source)
+        return StripPeakReadout(state: state, sourceByte: source)
     }
 
     // MARK: - Mute / Solo
@@ -271,54 +279,33 @@ struct HiLoSwitch: View {
 /// strip's fader / pickers / buttons / name field.
 struct StripMeter: View {
     @Bindable var state: MixerState
-    let source: SignalSource
-    var height: CGFloat = 220
+    let sourceByte: UInt8
+    var height: CGFloat = StripLayout.faderHeight
 
     var body: some View {
-        let live = level(from: state.peaks)
-        let held = level(from: state.peaksHeld)
-        let max_ = level(from: state.peaksMax)
+        let profile = state.device?.profile ?? .scarlett8i6
+        let live = level(from: state.peaks, profile: profile)
+        let held = level(from: state.peaksHeld, profile: profile)
+        let max_ = level(from: state.peaksMax, profile: profile)
         VerticalMeter(db: live, peakDb: held, maxPeakDb: max_, height: height)
     }
 
-    private func level(from peaks: PeakReading) -> Double {
-        Self.level(from: peaks, source: source)
+    private func level(from peaks: PeakReading, profile: DeviceProfile) -> Double {
+        peaks.level(forByte: sourceByte, profile: profile)
     }
 
-    static func level(from peaks: PeakReading, source: SignalSource) -> Double {
-        // Defer to PeakReading.level(for: MixBus) — every SignalSource case has
-        // the same raw byte value as the corresponding MixBus case, so a
-        // raw-value cross-conversion is exact.
-        peaks.level(for: MixBus(rawValue: source.rawValue) ?? .off)
+    static func level(from peaks: PeakReading, byte: UInt8, profile: DeviceProfile) -> Double {
+        peaks.level(forByte: byte, profile: profile)
     }
 }
 
 extension PeakReading {
-    /// Look up the meter value for whichever device-side meter slot
-    /// corresponds to a given signal source.  Returns -∞ for `.off` or
-    /// for sources the device doesn't surface a meter for.
-    func level(for source: MixBus) -> Double {
-        switch source {
-        case .off, .daw7, .daw8, .daw9, .daw10, .daw11, .daw12:
-            return -.infinity
-        case .daw1:    return daw[0]
-        case .daw2:    return daw[1]
-        case .daw3:    return daw[2]
-        case .daw4:    return daw[3]
-        case .daw5:    return daw[4]
-        case .daw6:    return daw[5]
-        case .analog1: return inputs[0]
-        case .analog2: return inputs[1]
-        case .analog3: return inputs[2]
-        case .analog4: return inputs[3]
-        case .spdif1:  return inputs[8]
-        case .spdif2:  return inputs[9]
-        case .m1:      return mixer[0]
-        case .m2:      return mixer[1]
-        case .m3:      return mixer[2]
-        case .m4:      return mixer[3]
-        case .m5:      return mixer[4]
-        case .m6:      return mixer[5]
+    func level(forByte byte: UInt8, profile: DeviceProfile) -> Double {
+        guard let slot = profile.peakSlot(forByte: byte) else { return -.infinity }
+        switch slot {
+        case .input(let i):  return inputs.indices.contains(i) ? inputs[i] : -.infinity
+        case .daw(let i):    return daw.indices.contains(i) ? daw[i] : -.infinity
+        case .mixer(let i):  return mixer.indices.contains(i) ? mixer[i] : -.infinity
         }
     }
 }
@@ -327,17 +314,18 @@ extension PeakReading {
 /// as `StripMeter` — only this view re-renders when the peak values change.
 struct StripPeakReadout: View {
     @Bindable var state: MixerState
-    let source: SignalSource
+    let sourceByte: UInt8
 
     var body: some View {
-        let peak = StripMeter.level(from: state.peaksHeld, source: source)
-        let max_ = StripMeter.level(from: state.peaksMax, source: source)
+        let profile = state.device?.profile ?? .scarlett8i6
+        let peak = StripMeter.level(from: state.peaksHeld, byte: sourceByte, profile: profile)
+        let max_ = StripMeter.level(from: state.peaksMax, byte: sourceByte, profile: profile)
         VStack(spacing: 1) {
             Text(formatPeak("Pk", peak))
                 .font(.system(size: 9, design: .monospaced))
                 .foregroundStyle(Theme.textSecondary)
             Button {
-                state.clearMaxPeak(forSource: source)
+                state.clearMaxPeak(forByte: sourceByte)
             } label: {
                 Text(formatPeak("Mx", max_))
                     .font(.system(size: 9, design: .monospaced))

--- a/Sources/ScarlettApp/ContentView.swift
+++ b/Sources/ScarlettApp/ContentView.swift
@@ -112,8 +112,12 @@ struct ContentView: View {
         HStack {
             if !sidebarCollapsed {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Scarlett 8i6").font(.headline).foregroundStyle(Theme.textPrimary)
-                    Text("1st Gen").font(.caption).foregroundStyle(Theme.textSecondary)
+                    Text(state.device?.profile.modelName ?? "Scarlett MixControl")
+                        .font(.headline)
+                        .foregroundStyle(Theme.textPrimary)
+                    Text("1st Gen")
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
                 }
                 Spacer(minLength: 0)
             }
@@ -302,15 +306,30 @@ struct RoutingView: View {
 
                 Panel(title: "Output assignments") {
                     VStack(spacing: 8) {
-                        stereoRouteRow("Monitor",  "Outputs 1+2 (rear jacks)", .monitorLeft, .monitorRight)
-                        stereoRouteRow("Phones",   "Outputs 3+4 (front jack / speakers)", .phonesLeft, .phonesRight)
-                        stereoRouteRow("S/PDIF",   "Digital out (RCA)", .spdifLeft, .spdifRight)
+                        let outputs = state.device?.profile.physicalOutputs ?? DeviceProfile.scarlett8i6.physicalOutputs
+                        let pairs = Dictionary(grouping: outputs, by: { $0.pairLabel })
+                            .values
+                            .map { $0.sorted { $0.isLeft && !$1.isLeft } }
+                            .sorted { $0[0].wValue < $1[0].wValue }
+                            .filter { $0.count == 2 }
+                        ForEach(pairs.indices, id: \.self) { idx in
+                            let pair = pairs[idx]
+                            let left = pair[0], right = pair[1]
+                            stereoRouteRow(
+                                title: left.pairLabel,
+                                subtitle: "Outputs \(left.wValue + 1)+\(right.wValue + 1)",
+                                left: left, right: right
+                            )
+                        }
                     }
                 }
 
                 Panel(title: "USB capture (what your DAW sees)") {
                     VStack(spacing: 8) {
-                        ForEach(0..<3, id: \.self) { pair in
+                        let totalCh = (state.device?.profile.captureChannelCount ?? 6)
+                                       + (state.device?.profile.loopbackChannelCount ?? 0)
+                        let pairs = totalCh / 2
+                        ForEach(0..<pairs, id: \.self) { pair in
                             stereoCaptureRow(
                                 "DAW input \(pair*2 + 1)+\(pair*2 + 2)",
                                 "Capture channels \(pair*2 + 1) (L) and \(pair*2 + 2) (R)",
@@ -320,7 +339,7 @@ struct RoutingView: View {
                     }
                 }
 
-                Text("Tip: routing reads always return 00 00 on the 1st-gen 8i6 — this app remembers your last setup in UserDefaults and re-pushes it to the device on launch.")
+                Text("Tip: routing reads always return 00 00 on the 1st-gen Scarlett — this app remembers your last setup in UserDefaults and re-pushes it to the device on launch.")
                     .font(.caption).foregroundStyle(Theme.textSecondary)
             }
             .padding(24)
@@ -332,7 +351,7 @@ struct RoutingView: View {
 
 extension RoutingView {
 
-    fileprivate func stereoRouteRow(_ title: String, _ subtitle: String, _ left: Route, _ right: Route) -> some View {
+    fileprivate func stereoRouteRow(title: String, subtitle: String, left: PhysicalOutput, right: PhysicalOutput) -> some View {
         HStack(alignment: .center, spacing: 14) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title).font(.subheadline.bold()).foregroundStyle(Theme.textPrimary)
@@ -340,8 +359,8 @@ extension RoutingView {
             }
             .frame(width: 220, alignment: .leading)
 
-            routePicker(label: "L", route: left)
-            routePicker(label: "R", route: right)
+            routePicker(label: "L", output: left)
+            routePicker(label: "R", output: right)
             Spacer(minLength: 0)
         }
         .padding(10)
@@ -349,15 +368,17 @@ extension RoutingView {
         .clipShape(RoundedRectangle(cornerRadius: 5))
     }
 
-    fileprivate func routePicker(label: String, route: Route) -> some View {
+    @ViewBuilder
+    fileprivate func routePicker(label: String, output: PhysicalOutput) -> some View {
+        let profile = state.device?.profile ?? .scarlett8i6
         HStack(spacing: 6) {
             Text(label).font(.caption.monospacedDigit()).foregroundStyle(Theme.textSecondary).frame(width: 12)
             ThemedMenuPicker(
-                options: MixBus.availableOn8i6,
+                options: profile.sources,
                 displayName: { $0.displayName },
                 selection: Binding(
-                    get: { state.routes[route] ?? .off },
-                    set: { state.userSetRoute(route, to: $0) }
+                    get: { profile.source(forByte: state.routes[Int(output.wValue)] ?? 0xff) },
+                    set: { state.userSetRoute(wValue: Int(output.wValue), sourceByte: $0.byte) }
                 ),
                 width: 150
             )
@@ -380,15 +401,17 @@ extension RoutingView {
         .clipShape(RoundedRectangle(cornerRadius: 5))
     }
 
+    @ViewBuilder
     fileprivate func capturePicker(label: String, channel: Int) -> some View {
+        let profile = state.device?.profile ?? .scarlett8i6
         HStack(spacing: 6) {
             Text(label).font(.caption.monospacedDigit()).foregroundStyle(Theme.textSecondary).frame(width: 12)
             ThemedMenuPicker(
-                options: MixBus.availableOn8i6,
+                options: profile.sources,
                 displayName: { $0.displayName },
                 selection: Binding(
-                    get: { state.captureRoutes[channel] ?? .off },
-                    set: { state.userSetCaptureRoute(channel: channel, to: $0) }
+                    get: { profile.source(forByte: state.captureRoutes[channel] ?? 0xff) },
+                    set: { state.userSetCaptureRoute(channel: channel, sourceByte: $0.byte) }
                 ),
                 width: 150
             )
@@ -425,7 +448,7 @@ struct DeviceView: View {
 
                 Panel(title: "Connection & driver") {
                     InfoGrid(rows: connectionRows)
-                    Text("The 1st-gen Scarlett 8i6 is USB Audio Class 2.0 — no Focusrite kernel driver, no installer. macOS's built-in usbaudiod claims the audio + MIDI interfaces; this app talks to endpoint 0 directly for DSP control transfers, which doesn't conflict.")
+                    Text("All 1st-gen Scarletts are USB Audio Class 2.0 — no Focusrite kernel driver, no installer. macOS's built-in usbaudiod claims the audio + MIDI interfaces; this app talks to endpoint 0 directly for DSP control transfers, which doesn't conflict.")
                         .font(.caption).foregroundStyle(Theme.textSecondary)
                         .padding(.top, 6)
                 }
@@ -521,7 +544,7 @@ struct DeviceView: View {
                         Text("Compatibility")
                             .font(.subheadline.bold())
                             .foregroundStyle(Theme.textPrimary)
-                        Text("Original MixControl supported six 1st-generation Scarlett interfaces. So far only the 8i6 has been ported here — the others share the protocol family but each has its own byte tables to reverse-engineer from the original binary.")
+                        Text("Original MixControl supported six 1st-generation Scarlett interfaces. The 8i6 is fully supported (primary target) and the 18i8 has experimental support; the others share the protocol family but each has its own byte tables from the original binary.")
                             .font(.caption)
                             .foregroundStyle(Theme.textSecondary)
                             .fixedSize(horizontal: false, vertical: true)
@@ -530,6 +553,9 @@ struct DeviceView: View {
                             compatRow(symbol: "checkmark.circle.fill",
                                       color: .green,
                                       text: "Scarlett 8i6 — tested, primary target")
+                            compatRow(symbol: "checkmark.circle.fill",
+                                      color: .green,
+                                      text: "Scarlett 18i8 — experimental support")
                             compatRow(symbol: "questionmark.circle",
                                       color: .orange,
                                       text: "Scarlett 6i6 — supported by original MixControl, not yet ported")
@@ -539,9 +565,6 @@ struct DeviceView: View {
                             compatRow(symbol: "questionmark.circle",
                                       color: .orange,
                                       text: "Scarlett 18i6 — supported by original MixControl, not yet ported")
-                            compatRow(symbol: "questionmark.circle",
-                                      color: .orange,
-                                      text: "Scarlett 18i8 — supported by original MixControl, not yet ported")
                             compatRow(symbol: "questionmark.circle",
                                       color: .orange,
                                       text: "Scarlett 18i20 — supported by original MixControl, not yet ported")
@@ -687,7 +710,7 @@ struct ConnectionOverlayCard: View {
             return (
                 .orange,
                 "antenna.radiowaves.left.and.right.slash",
-                "Waiting for Scarlett 8i6",
+                "Waiting for Scarlett",
                 "Plug the device in via USB. The app will reconnect automatically."
             )
         case .disconnected(let reason):
@@ -702,7 +725,7 @@ struct ConnectionOverlayCard: View {
                 .yellow,
                 "exclamationmark.triangle.fill",
                 "\(p.displayName) detected — not yet supported",
-                "This Community Edition currently only supports the Scarlett 8i6 (1st gen). We've detected your \(p.displayName) on the bus but can't drive its mixer yet — the byte mappings differ between models.\n\nSupport for other 1st-gen Scarletts is on the roadmap. If you'd like to help, the project is open source and the byte tables can be extracted from the original MixControl binary the same way the 8i6 was — see the project README."
+                "This Community Edition supports the Scarlett 8i6 and 18i8 (1st gen). We've detected your \(p.displayName) on the bus but can't drive its mixer yet — the byte mappings differ between models.\n\nSupport for other 1st-gen Scarletts is on the roadmap. If you'd like to help, the project is open source and the byte tables can be extracted from the original MixControl binary the same way the 8i6 was — see the project README."
             )
         }
     }
@@ -728,10 +751,10 @@ struct FirstLaunchCard: View {
                     .font(.title3)            // regular weight — visual contrast with the bold title above
                     .foregroundStyle(Theme.textPrimary)
             }
-            Text("For the Scarlett 8i6 (1st gen)")
+            Text("For the \(state.device?.profile.displayName ?? "Scarlett 8i6") (1st gen)")
                 .font(.caption)
                 .foregroundStyle(Theme.textSecondary)
-            Text("Your Scarlett 8i6 keeps its routing and mixer state in flash. Keep what's already on the device, or start from a clean default config?")
+            Text("Your \(state.device?.profile.displayName ?? "Scarlett") keeps its routing and mixer state in flash. Keep what's already on the device, or start from a clean default config?")
                 .font(.callout)
                 .foregroundStyle(Theme.textSecondary)
                 .multilineTextAlignment(.center)

--- a/Sources/ScarlettApp/MatrixView.swift
+++ b/Sources/ScarlettApp/MatrixView.swift
@@ -3,13 +3,18 @@ import ScarlettCore
 
 /// The matrix mixer view — Control 2 style.
 ///
-/// Top bar: bus tabs (Mix M1..M6).
-/// Below: horizontally scrolling row of `ChannelStrip`s, one per matrix
-/// channel that we expose to the user (first 14 of the 18 protocol slots —
-/// the rest aren't useful on the 8i6).
+/// Top bar: bus tabs (number from active DeviceProfile).
+/// Below: two rows of horizontally scrolling `ChannelStrip`s.
 struct MatrixMixerView: View {
     @Bindable var state: MixerState
-    private let visibleChannels = 0..<14
+
+    private var visibleChannels: Range<Int> {
+        0..<(state.device?.profile.matrixInputCount ?? 18)
+    }
+
+    private var busCount: Int {
+        state.device?.profile.mixBusCount ?? 6
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -31,13 +36,14 @@ struct MatrixMixerView: View {
     }
 
     private var busTabs: some View {
-        HStack(spacing: 4) {
-            ForEach(MixBus.matrixOutputs) { bus in
-                let selected = state.selectedBus == bus
+        let busCount = busCount
+        return HStack(spacing: 4) {
+            ForEach(0..<busCount, id: \.self) { idx in
+                let selected = state.selectedBusIndex == idx
                 Button {
-                    state.selectedBus = bus
+                    state.selectedBusIndex = idx
                 } label: {
-                    Text(bus.displayName)
+                    Text("M\(idx + 1)")
                         .font(.system(size: 12, weight: .semibold))
                         .frame(width: 60, height: 28)
                         .background(selected ? Theme.muteActive : Theme.panelRaised)
@@ -45,7 +51,7 @@ struct MatrixMixerView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 4))
                 }
                 .buttonStyle(.plain)
-                .contextMenu { copyMixMenuItems(targetBus: bus) }
+                .contextMenu { copyMixMenuItems(targetBusIndex: idx) }
             }
             Spacer()
             actionButton(icon: "arrow.counterclockwise", label: "Clear peaks") {
@@ -71,13 +77,12 @@ struct MatrixMixerView: View {
         }
     }
 
-    /// Context-menu items for a bus tab — copy this pair's settings to one
-    /// of the other two pairs.  Right-click any bus tab to access.
     @ViewBuilder
-    private func copyMixMenuItems(targetBus: MixBus) -> some View {
-        let sourcePair = targetBus.stereoPairIndex ?? 0
+    private func copyMixMenuItems(targetBusIndex: Int) -> some View {
+        let sourcePair = targetBusIndex / 2
+        let busPairs = (busCount + 1) / 2
         let pairLabel: (Int) -> String = { p in "M\(p*2 + 1)+M\(p*2 + 2)" }
-        ForEach(0..<3, id: \.self) { dest in
+        ForEach(0..<busPairs, id: \.self) { dest in
             if dest != sourcePair {
                 Button("Copy \(pairLabel(sourcePair)) → \(pairLabel(dest))") {
                     state.userCopyMixPair(from: sourcePair, to: dest)
@@ -108,14 +113,29 @@ struct MatrixMixerView: View {
     }
 
     private var strips: some View {
-        HStack(alignment: .top, spacing: 6) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 6) {
-                    ForEach(visibleChannels, id: \.self) { ch in
-                        ChannelStrip(channel: ch, state: state)
+        let ch = visibleChannels
+        let count = ch.count
+        let mid = count / 2
+        let topHalf = ch.lowerBound..<ch.lowerBound + mid
+        let botHalf = ch.lowerBound + mid..<ch.upperBound
+        return HStack(alignment: .top, spacing: 6) {
+            VStack(spacing: StripLayout.vSpacing) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(topHalf, id: \.self) { ch in
+                            ChannelStrip(channel: ch, state: state)
+                        }
                     }
+                    .padding(.vertical, StripLayout.rowPaddingV)
                 }
-                .padding(.vertical, 4)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(botHalf, id: \.self) { ch in
+                            ChannelStrip(channel: ch, state: state)
+                        }
+                    }
+                    .padding(.vertical, StripLayout.rowPaddingV)
+                }
             }
             PinnedDawStrip(state: state)
             PinnedMasterStrip(state: state)

--- a/Sources/ScarlettApp/MixerState.swift
+++ b/Sources/ScarlettApp/MixerState.swift
@@ -5,14 +5,14 @@ import CoreAudio
 import IOKit
 import ScarlettCore
 
-/// High-level connection state of the Scarlett 8i6.  Tracked separately from
+/// High-level connection state of the Scarlett device.  Tracked separately from
 /// the device handle so the UI can render meaningful "waiting" / "disconnected"
 /// states distinct from "open but erroring on a single transfer".
 public enum ConnectionState: Equatable {
     case waiting                          // App is up, nothing plugged in yet
     case connected                        // Device handle opened and last poll succeeded
     case disconnected(String)             // Was connected, lost — reason for display
-    case unsupported(DeviceProfile)       // Found a Focusrite, but it's not the 8i6 we officially support
+    case unsupported(DeviceProfile)       // Found a Focusrite with no DeviceProfile match at all
 }
 
 // View model holding the live device handle, the latest peak meter reading,
@@ -81,11 +81,9 @@ final class MixerState {
     var hi4: Bool = false
 
     // Routing — default "Off" displayed, not pushed on launch.
-    var routes: [Route: MixBus] = [
-        .monitorLeft: .off, .monitorRight: .off,
-        .phonesLeft:  .off, .phonesRight:  .off,
-        .spdifLeft:   .off, .spdifRight:   .off,
-    ]
+    // Key is physical-output wValue (0..<profile.physicalOutputs.count);
+    // value is the source byte from profile.sources (0xff = write Off).
+    var routes: [Int: UInt8] = [:]
 
     // Device config — default values shown, not pushed on launch.
     var clock: ClockSource = .internalClock
@@ -108,25 +106,24 @@ final class MixerState {
     var phonesRMuted:  Bool = false
 
     /// Per-USB-capture-channel routing — what the DAW sees on each of its
-    /// input channels.  6 entries (DAW input 1..6).  Default values mirror
-    /// what MixControl applies on first launch: capture 1..4 = Analog 1..4,
-    /// capture 5..6 = S/PDIF 1..2.  Persisted to UserDefaults like routes.
-    var captureRoutes: [Int: MixBus] = [
-        0: .analog1, 1: .analog2, 2: .analog3, 3: .analog4,
-        4: .spdif1,  5: .spdif2,
-    ]
+    /// input channels.  Key is capture-channel index, value is source byte.
+    /// Persisted to UserDefaults like routes.
+    var captureRoutes: [Int: UInt8] = [:]
 
-    // Matrix mixer: 18 input channels × 6 mix buses (M1..M6).  The user-
-    // facing knobs are `mixerLevels` + `mixerPans` + `mixerMutes` +
+    // Matrix mixer: 18 input channels × up to 8 mix buses (M1..M8).  The
+    // user-facing knobs are `mixerLevels` + `mixerPans` + `mixerMutes` +
     // `mixerSolos`.  The per-cell gain actually sent to the device is
     // computed on demand by `effectiveGain(...)` from those four fields.
-    var mixerSources: [SignalSource] = Array(repeating: .off, count: 18)
-    /// One fader value per channel per stereo bus pair (M1+M2, M3+M4, M5+M6).
-    /// Range -60…+6 dB, default 0.
-    var mixerLevels: [[Double]] = Array(repeating: Array(repeating: 0, count: 3), count: 18)
-    /// One pan position per channel per stereo bus pair. -1 = full left,
-    /// 0 = center (no attenuation either side), +1 = full right.
-    var mixerPans:   [[Double]] = Array(repeating: Array(repeating: 0, count: 3), count: 18)
+    // Storage uses raw source bytes (from DeviceProfile.sources) rather
+    // than device-specific enums; views resolve display names through
+    // DeviceProfile.source(forByte:).
+    var mixerSources: [UInt8] = Array(repeating: 0xff, count: 18)
+    /// One fader value per channel per stereo bus pair.  Inner dimension
+    /// must be at least mixBusCount/2 (4 for 18i8, 3 for 8i6).  We size
+    /// for the maximum so the model stays profile-agnostic.
+    var mixerLevels: [[Double]] = Array(repeating: Array(repeating: 0, count: 4), count: 18)
+    /// One pan position per channel per stereo bus pair.
+    var mixerPans:   [[Double]] = Array(repeating: Array(repeating: 0, count: 4), count: 18)
     /// Per-channel mute — silences the channel's contribution to every
     /// mix bus.  Matches how M behaves on a real mixer / in MixControl.
     var mixerMutes: [Bool] = Array(repeating: false, count: 18)
@@ -154,13 +151,41 @@ final class MixerState {
     @ObservationIgnored private let maxEvents = 100
     @ObservationIgnored private var coreAudioListenerInstalled = false
     @ObservationIgnored private var lastCoreAudioPresence: Bool = false
-    var selectedBus: MixBus = .m1 {
+    @ObservationIgnored private var didLaunchBackup = false
+    var selectedBusIndex: Int = 0 {
         didSet { saveSelectedBus() }
     }
 
     init() {
+        UserDefaults.standard.register(defaults: [
+            "scarlett.autoBackupOnReset": true,
+            "scarlett.autoBackupOnLaunch": false,
+            "scarlett.autoBackupOnQuit": false,
+        ])
         installCoreAudioListener()
         attemptConnect()
+    }
+
+    /// Formatter for auto-backup timestamps.
+    private static let backupFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return f
+    }()
+
+    /// Save a snapshot with a descriptive auto-backup label and the
+    /// current device profile name.  Checks the relevant UserDefaults
+    /// toggle before saving — call only when the toggle is already known
+    /// to be true, or use the convenience methods below.
+    func userAutoSaveBackup(label: String) {
+        let ts = Self.backupFormatter.string(from: Date())
+        let tag: String
+        if let name = device?.profile.displayName {
+            tag = "\(name) "
+        } else {
+            tag = ""
+        }
+        userSavePreset(name: "Auto-saved \(label) – \(tag)\(ts)")
     }
 
     /// Try to (re-)open the device and refresh all state.  Idempotent.
@@ -171,19 +196,12 @@ final class MixerState {
         let wasConnected = isConnected
         do {
             let dev = try ScarlettDevice()
-            // We officially support only the 8i6.  Other 1st-gen Scarletts
-            // are detected (so we can tell the user what they have), but
-            // we don't run the matrix/routing flow against them — the byte
-            // tables differ and we'd send wrong commands.
-            guard !dev.profile.isExperimental else {
-                self.device = nil
-                if connection != .unsupported(dev.profile) {
-                    logEvent(.warning, "Connection",
-                             "Detected \(dev.profile.displayName) — not officially supported")
-                }
-                connection = .unsupported(dev.profile)
-                return
-            }
+            // Any DeviceProfile match is fair game: the profile-driven
+            // protocol layer (Phase 1) and profile-keyed storage (Phase 2)
+            // pick the right bytes per device.  `.unsupported` is now only
+            // for PIDs with no DeviceProfile at all — which `ScarlettDevice`
+            // itself throws `deviceNotFound` for, so this branch is
+            // effectively dead code today but kept for forward-compat.
             self.device = dev
             if let bcd = dev.firmwareBCD() {
                 let hi = (bcd >> 8) & 0xff
@@ -196,11 +214,20 @@ final class MixerState {
             refreshFromDevice()
             loadPersistedState()
             ensurePinnedDawChannels()
+            // Push default routes so Mix M1 routing takes effect.
+            pushDefaultRoutes()
             if !wasConnected {
                 logEvent(.info, "Connection",
-                         "Connected to Scarlett 8i6 (firmware \(firmware), serial \(serial))")
+                         "Connected to \(dev.profile.displayName) (firmware \(firmware), serial \(serial))")
             }
             connection = .connected
+            if !didLaunchBackup {
+                didLaunchBackup = true
+                if UserDefaults.standard.bool(forKey: "scarlett.autoBackupOnLaunch") {
+                    userAutoSaveBackup(label: "at launch")
+                    logEvent(.info, "Backup", "Auto-saved launch snapshot")
+                }
+            }
         } catch ScarlettError.deviceNotFound {
             self.device = nil
             // Clear meters so we don't show stale levels frozen from before.
@@ -271,13 +298,13 @@ final class MixerState {
                 self.lastCoreAudioPresence = present
                 if present {
                     self.logEvent(.info, "Core Audio",
-                                  "Scarlett 8i6 visible to Core Audio")
+                                  "Scarlett visible to Core Audio")
                     // Device just appeared — kick a connect attempt so we
                     // don't wait the full 2 s for the polling loop's retry.
                     if !self.isConnected { self.attemptConnect() }
                 } else {
                     self.logEvent(.warning, "Core Audio",
-                                  "Scarlett 8i6 disappeared from Core Audio device list")
+                                  "Scarlett disappeared from Core Audio device list")
                     if self.isConnected {
                         self.device = nil
                         self.connection = .disconnected("Removed from Core Audio")
@@ -347,8 +374,8 @@ final class MixerState {
     private static let firstLaunchDoneKey   = "scarlett.firstLaunchCompleted.v1"
 
     private struct PersistedMatrix: Codable {
-        var levels: [[Double]]      // 18 × 3, per-channel-per-pair
-        var pans: [[Double]]        // 18 × 3
+        var levels: [[Double]]      // 18 × busPairCount, per-channel-per-pair
+        var pans: [[Double]]        // 18 × busPairCount
         var mutes: [Bool]           // 18, per-channel
         var solos: [Bool]           // 18, per-channel
         var sources: [UInt8]        // 18, SignalSource.rawValue per channel
@@ -362,12 +389,11 @@ final class MixerState {
         // Routes — re-push to device so it actually honors them.
         if let data = defaults.data(forKey: Self.routesKey),
            let dict = try? JSONDecoder().decode([UInt16: UInt8].self, from: data) {
-            for (routeRaw, busRaw) in dict {
-                guard let route = Route(rawValue: routeRaw),
-                      let bus = MixBus(rawValue: busRaw) else { continue }
-                routes[route] = bus
-                if let dev = device {
-                    writeAsync { try? dev.setRouteSource(route, from: bus) }
+            for (wValue, sourceByte) in dict {
+                routes[Int(wValue)] = sourceByte
+                if let dev = device,
+                   let output = dev.profile.physicalOutputs.first(where: { $0.wValue == wValue }) {
+                    writeAsync { try? dev.setPhysicalRouteSource(output, sourceByte: sourceByte) }
                 }
             }
         }
@@ -379,9 +405,8 @@ final class MixerState {
         // defaults active (Analog/SPDIF → DAW captures) which is fine.
         if let data = defaults.data(forKey: Self.captureRoutesKey),
            let dict = try? JSONDecoder().decode([UInt16: UInt8].self, from: data) {
-            for (chRaw, busRaw) in dict {
-                guard let bus = MixBus(rawValue: busRaw) else { continue }
-                captureRoutes[Int(chRaw)] = bus
+            for (ch, sourceByte) in dict {
+                captureRoutes[Int(ch)] = sourceByte
             }
         }
 
@@ -389,12 +414,11 @@ final class MixerState {
         // device remembers this across power cycles too.
         monitorMono = defaults.bool(forKey: Self.monitorMonoKey)
 
-        // Selected bus tab
-        // Persisted bus index is the matrix-index (0..5), not the byte value,
-        // for stability across enum byte-value changes.
+        // Selected bus tab — persisted as a plain UInt8 index (0..mixBusCount).
         if let raw = defaults.object(forKey: Self.busTabKey) as? UInt8,
-           raw < UInt8(MixBus.matrixOutputs.count) {
-            selectedBus = MixBus.matrixOutputs[Int(raw)]
+           let p = device?.profile,
+           raw < UInt8(p.mixBusCount) {
+            selectedBusIndex = Int(raw)
         }
 
         // Matrix state: mute/solo/names/links/sources/levels/pans.
@@ -404,26 +428,24 @@ final class MixerState {
         // the UI says regardless of what state the device booted in.
         if let data = defaults.data(forKey: Self.matrixKey),
            let m = try? JSONDecoder().decode(PersistedMatrix.self, from: data),
-           m.levels.count == 18, m.levels.allSatisfy({ $0.count == 3 }),
-           m.pans.count   == 18, m.pans.allSatisfy({ $0.count == 3 }),
+           m.levels.count == 18, m.levels.allSatisfy({ $0.count >= 3 }),
+           m.pans.count   == 18, m.pans.allSatisfy({ $0.count >= 3 }),
            m.mutes.count  == 18, m.solos.count == 18,
            m.sources.count == 18, m.names.count == 18
         {
-            mixerLevels = m.levels
-            mixerPans = m.pans
+            mixerLevels = m.levels.map { $0 + Array(repeating: 0, count: max(0, 4 - $0.count)) }
+            mixerPans = m.pans.map { $0 + Array(repeating: 0, count: max(0, 4 - $0.count)) }
             mixerMutes = m.mutes
             mixerSolos = m.solos
             mixerNames = m.names
             linkedPairs = Set(m.linkedLefts)
             for ch in 0..<18 {
-                if let v = SignalSource(rawValue: m.sources[ch]) {
-                    mixerSources[ch] = v
-                }
+                mixerSources[ch] = m.sources[ch]
             }
-            if device != nil {
+            if let p = device?.profile {
                 for ch in 0..<18 {
-                    for bus in MixBus.matrixOutputs {
-                        pushCellGain(channel: ch, bus: bus)
+                    for bus in 0..<p.mixBusCount {
+                        pushCellGainRaw(channel: ch, busIndex: bus)
                     }
                 }
             }
@@ -460,7 +482,7 @@ final class MixerState {
 
     private func saveRoutes() {
         let dict = Dictionary(uniqueKeysWithValues:
-            routes.map { ($0.key.rawValue, $0.value.rawValue) })
+            routes.map { (UInt16($0.key), $0.value) })
         if let data = try? JSONEncoder().encode(dict) {
             UserDefaults.standard.set(data, forKey: Self.routesKey)
         }
@@ -468,7 +490,7 @@ final class MixerState {
 
     private func saveCaptureRoutes() {
         let dict = Dictionary(uniqueKeysWithValues:
-            captureRoutes.map { (UInt16($0.key), $0.value.rawValue) })
+            captureRoutes.map { (UInt16($0.key), $0.value) })
         if let data = try? JSONEncoder().encode(dict) {
             UserDefaults.standard.set(data, forKey: Self.captureRoutesKey)
         }
@@ -479,9 +501,7 @@ final class MixerState {
     }
 
     private func saveSelectedBus() {
-        // Save the matrix index (0..5) rather than the raw byte so the
-        // persisted value survives any future enum byte-value change.
-        UserDefaults.standard.set(UInt8(selectedBus.matrixIndex ?? 0), forKey: Self.busTabKey)
+        UserDefaults.standard.set(UInt8(selectedBusIndex), forKey: Self.busTabKey)
     }
 
     private func saveMatrix() {
@@ -490,7 +510,7 @@ final class MixerState {
             pans: mixerPans,
             mutes: mixerMutes,
             solos: mixerSolos,
-            sources: mixerSources.map { $0.rawValue },
+            sources: mixerSources,
             names: mixerNames,
             linkedLefts: Array(linkedPairs)
         )
@@ -499,7 +519,7 @@ final class MixerState {
         }
     }
 
-    private func savePresets() {
+    func savePresets() {
         if let data = try? JSONEncoder().encode(presets) {
             UserDefaults.standard.set(data, forKey: Self.presetsKey)
         }
@@ -555,21 +575,21 @@ final class MixerState {
         // reads.  We pull them all into a local [[Double]] just long enough
         // to derive the user-facing level + pan model — there's no separate
         // persistent gains field.
-        var snapshotGains: [[Double]] = Array(repeating: Array(repeating: 0, count: 6),
+        let mixBusCount = dev.profile.mixBusCount
+        var snapshotGains: [[Double]] = Array(repeating: Array(repeating: 0, count: mixBusCount),
                                               count: 18)
         for ch in 0..<18 {
-            if let v = try? dev.getMixerSource(channel: ch) {
+            if let v = try? dev.getMixerSourceByte(channel: ch) {
                 mixerSources[ch] = v
             }
-            for bus in MixBus.matrixOutputs {
-                guard let idx = bus.matrixIndex else { continue }
-                if let v = try? dev.getMixerGain(channel: ch, bus: bus) {
-                    snapshotGains[ch][idx] = v
+            for busIdx in 0..<mixBusCount {
+                if let v = try? dev.getMixerGainRaw(channel: ch, busIndex: busIdx) {
+                    snapshotGains[ch][busIdx] = v
                 }
             }
         }
         for ch in 0..<18 {
-            for pair in 0..<3 {
+            for pair in 0..<mixBusCount / 2 {
                 let (level, pan) = Self.deriveLevelAndPan(
                     left:  snapshotGains[ch][pair * 2],
                     right: snapshotGains[ch][pair * 2 + 1]
@@ -725,21 +745,22 @@ final class MixerState {
 
     // MARK: - Routing
 
-    func userSetRoute(_ route: Route, to source: MixBus) {
-        routes[route] = source
+    func userSetRoute(wValue: Int, sourceByte: UInt8) {
+        routes[wValue] = sourceByte
         saveRoutes()
-        guard let dev = device else { return }
-        writeAsync { try? dev.setRouteSource(route, from: source) }
+        guard let dev = device,
+              let output = dev.profile.physicalOutputs.first(where: { $0.wValue == UInt16(wValue) })
+        else { return }
+        writeAsync { try? dev.setPhysicalRouteSource(output, sourceByte: sourceByte) }
     }
 
-    /// Set what the DAW sees on USB capture channel `channel` (0..5 on the
-    /// 8i6).  Persists and pushes to the device.
-    func userSetCaptureRoute(channel: Int, to source: MixBus) {
-        guard (0...7).contains(channel) else { return }
-        captureRoutes[channel] = source
+    /// Set what the DAW sees on USB capture channel `channel`.
+    /// Persists and pushes to the device.
+    func userSetCaptureRoute(channel: Int, sourceByte: UInt8) {
+        captureRoutes[channel] = sourceByte
         saveCaptureRoutes()
         guard let dev = device else { return }
-        writeAsync { try? dev.setCaptureRoute(channel: channel, from: source) }
+        writeAsync { try? dev.setCaptureRouteSource(channel: channel, sourceByte: sourceByte) }
     }
 
     // MARK: - Monitor mono
@@ -841,11 +862,11 @@ final class MixerState {
     static func pairIndex(of bus: MixBus) -> Int { bus.stereoPairIndex ?? 0 }
     static func isLeftSide(of bus: MixBus) -> Bool { bus.isLeftOfPair }
 
-    func userSetMixerSource(channel: Int, source: SignalSource) {
+    func userSetMixerSource(channel: Int, sourceByte: UInt8) {
         guard (0..<18).contains(channel) else { return }
-        mixerSources[channel] = source
+        mixerSources[channel] = sourceByte
         guard let dev = device else { return }
-        writeAsync { try? dev.setMixerSource(channel: channel, source: source) }
+        writeAsync { try? dev.setMixerSourceByte(channel: channel, sourceByte: sourceByte) }
     }
 
     // MARK: - Pinned DAW return
@@ -872,11 +893,12 @@ final class MixerState {
         // DAW 1 is already wired to (say) ch 0 from the factory default, a
         // bare `setMixerSource(14, .daw1)` is silently rejected and ch 14
         // stays pointed at whatever it was sourced from before.  We have to
-        // disconnect the existing owner with `.off` first.
-        assignPinnedSource(channel: l, source: .daw1)
-        assignPinnedSource(channel: r, source: .daw2)
+        // disconnect the existing owner with `0xff` (Off) first.
+        assignPinnedSource(channel: l, sourceByte: 0x00)  // DAW 1
+        assignPinnedSource(channel: r, sourceByte: 0x01)  // DAW 2
 
-        for pair in 0..<3 {
+        let busPairs = min((device?.profile.mixBusCount ?? 6) / 2, mixerPans[l].count)
+        for pair in 0..<busPairs {
             if mixerPans[l][pair] != -1 { userSetMixerPan(channel: l, pair: pair, pan: -1) }
             if mixerPans[r][pair] !=  1 { userSetMixerPan(channel: r, pair: pair, pan:  1) }
         }
@@ -889,20 +911,20 @@ final class MixerState {
     /// Helper for `ensurePinnedDawChannels`: claim a specific source for one
     /// channel, disconnecting it from any other channel that currently holds
     /// it.  Skips work if the target already has the desired source.
-    private func assignPinnedSource(channel target: Int, source desired: SignalSource) {
+    private func assignPinnedSource(channel target: Int, sourceByte desired: UInt8) {
         guard (0..<18).contains(target) else { return }
         if mixerSources[target] == desired { return }
 
         // Disconnect any other channel that currently has this source —
         // otherwise the device won't reassign it to us.
         for ch in 0..<18 where ch != target && mixerSources[ch] == desired {
-            userSetMixerSource(channel: ch, source: .off)
+            userSetMixerSource(channel: ch, sourceByte: 0xff)
         }
 
         // Now claim it on the target.  These writes are queued on the same
         // serial USB queue, so the disconnect above lands before the new
         // assignment hits the device.
-        userSetMixerSource(channel: target, source: desired)
+        userSetMixerSource(channel: target, sourceByte: desired)
     }
 
     // MARK: - Stereo link
@@ -923,17 +945,31 @@ final class MixerState {
         let left = Self.leftOfPair(ch)
         if linkedPairs.contains(left) {
             linkedPairs.remove(left)
+            for pair in 0..<busPairCount {
+                mixerPans[left][pair] = 0
+                mixerPans[left + 1][pair] = 0
+                pushBusPair(channel: left, pair: pair)
+            }
         } else {
             linkedPairs.insert(left)
+            for pair in 0..<busPairCount {
+                mixerPans[left][pair] = -1
+                mixerPans[left + 1][pair] = 1
+                pushBusPair(channel: left, pair: pair)
+            }
         }
         saveMatrix()
     }
+
+    /// Number of stereo bus pairs (mixBusCount / 2).  Profile-driven so
+    /// it's 3 on 8i6/18i6 and 4 on 18i8 without hardcoding.
+    private var busPairCount: Int { (device?.profile.mixBusCount ?? 6) / 2 }
 
     /// Set the channel-level fader for one stereo bus pair. Pushes both cells
     /// (L and R) in that pair to the device.  If the channel is in a linked
     /// stereo pair, the partner's level for the same pair moves with it.
     func userSetMixerLevel(channel: Int, pair: Int, level: Double) {
-        guard (0..<18).contains(channel), (0..<3).contains(pair) else { return }
+        guard (0..<18).contains(channel), (0..<busPairCount).contains(pair) else { return }
         mixerLevels[channel][pair] = level
         pushBusPair(channel: channel, pair: pair)
         if let partner = linkedPartner(channel) {
@@ -946,20 +982,24 @@ final class MixerState {
     /// Set the L↔R pan for one stereo bus pair on one channel. Snaps to
     /// center when within ±0.04.
     func userSetMixerPan(channel: Int, pair: Int, pan: Double) {
-        guard (0..<18).contains(channel), (0..<3).contains(pair) else { return }
+        guard (0..<18).contains(channel), (0..<busPairCount).contains(pair) else { return }
         let snapped = abs(pan) < 0.04 ? 0 : max(-1, min(1, pan))
         mixerPans[channel][pair] = snapped
         pushBusPair(channel: channel, pair: pair)
+        if let partner = linkedPartner(channel) {
+            let partnerPan = -snapped
+            mixerPans[partner][pair] = partnerPan
+            pushBusPair(channel: partner, pair: pair)
+        }
         saveMatrix()
     }
 
     private func pushBusPair(channel: Int, pair: Int) {
-        let outs = MixBus.matrixOutputs
         let leftIdx = pair * 2
         let rightIdx = pair * 2 + 1
-        guard leftIdx < outs.count, rightIdx < outs.count else { return }
-        pushCellGain(channel: channel, bus: outs[leftIdx])
-        pushCellGain(channel: channel, bus: outs[rightIdx])
+        guard let p = device?.profile, leftIdx < p.mixBusCount, rightIdx < p.mixBusCount else { return }
+        pushCellGainRaw(channel: channel, busIndex: leftIdx)
+        pushCellGainRaw(channel: channel, busIndex: rightIdx)
     }
 
     func userSetChannelName(channel: Int, name: String) {
@@ -973,38 +1013,15 @@ final class MixerState {
         peaksMax = .empty
     }
 
-    /// Reset the all-time max peak for one signal source / mix-bus source.
-    /// Both old call-sites (`forSource`, `forMixBus`) collapse into this one
-    /// once we map a `SignalSource` to its `MixBus` equivalent.
-    func clearMaxPeak(_ source: MixBus) {
-        switch source {
-        case .daw1:    peaksMax.daw[0] = -.infinity
-        case .daw2:    peaksMax.daw[1] = -.infinity
-        case .daw3:    peaksMax.daw[2] = -.infinity
-        case .daw4:    peaksMax.daw[3] = -.infinity
-        case .daw5:    peaksMax.daw[4] = -.infinity
-        case .daw6:    peaksMax.daw[5] = -.infinity
-        case .analog1: peaksMax.inputs[0] = -.infinity
-        case .analog2: peaksMax.inputs[1] = -.infinity
-        case .analog3: peaksMax.inputs[2] = -.infinity
-        case .analog4: peaksMax.inputs[3] = -.infinity
-        case .spdif1:  peaksMax.inputs[8] = -.infinity
-        case .spdif2:  peaksMax.inputs[9] = -.infinity
-        case .m1:      peaksMax.mixer[0] = -.infinity
-        case .m2:      peaksMax.mixer[1] = -.infinity
-        case .m3:      peaksMax.mixer[2] = -.infinity
-        case .m4:      peaksMax.mixer[3] = -.infinity
-        case .m5:      peaksMax.mixer[4] = -.infinity
-        case .m6:      peaksMax.mixer[5] = -.infinity
-        case .off, .daw7, .daw8, .daw9, .daw10, .daw11, .daw12: break
+    /// Reset a single source's max-peak track (clicking "Mx" on a strip).
+    func clearMaxPeak(forByte byte: UInt8) {
+        guard let profile = device?.profile,
+              let slot = profile.peakSlot(forByte: byte) else { return }
+        switch slot {
+        case .input(let i):  if peaksMax.inputs.indices.contains(i) { peaksMax.inputs[i] = -.infinity }
+        case .daw(let i):    if peaksMax.daw.indices.contains(i)    { peaksMax.daw[i]    = -.infinity }
+        case .mixer(let i):  if peaksMax.mixer.indices.contains(i)  { peaksMax.mixer[i]  = -.infinity }
         }
-    }
-
-    /// Convenience wrapper so `SignalSource`-typed call-sites (matrix-channel
-    /// strips) don't need to construct a `MixBus` themselves.  Every valid
-    /// `SignalSource` has the same raw byte value in `MixBus`.
-    func clearMaxPeak(forSource source: SignalSource) {
-        clearMaxPeak(MixBus(rawValue: source.rawValue) ?? .off)
     }
 
     // MARK: - Presets
@@ -1018,15 +1035,15 @@ final class MixerState {
             name: trimmed,
             createdAt: Date(),
             routes: Dictionary(uniqueKeysWithValues:
-                routes.map { ($0.key.rawValue, $0.value.rawValue) }),
-            mixerSources: mixerSources.map { $0.rawValue },
+                routes.map { (UInt16($0.key), $0.value) }),
+            mixerSources: mixerSources,
             mixerLevels: mixerLevels,
             mixerPans: mixerPans,
             mixerMutes: mixerMutes,
             mixerSolos: mixerSolos,
             mixerNames: mixerNames,
             linkedLefts: Array(linkedPairs),
-            selectedBus: UInt8(selectedBus.matrixIndex ?? 0)
+            selectedBus: UInt8(selectedBusIndex)
         )
 
         // Replace any preset with the same name; otherwise append.
@@ -1039,23 +1056,23 @@ final class MixerState {
     }
 
     func userLoadPreset(_ preset: ScarlettPreset) {
-        guard let dev = device else { return }
+        guard let dev = device, let p = device?.profile else { return }
 
         // Routes
-        for (routeRaw, busRaw) in preset.routes {
-            guard let route = Route(rawValue: routeRaw),
-                  let bus = MixBus(rawValue: busRaw) else { continue }
-            routes[route] = bus
-            writeAsync { try? dev.setRouteSource(route, from: bus) }
+        for (routeRaw, busByte) in preset.routes {
+            routes[Int(routeRaw)] = busByte
+            if let output = p.physicalOutputs.first(where: { $0.wValue == routeRaw }) {
+                writeAsync { try? dev.setPhysicalRouteSource(output, sourceByte: busByte) }
+            }
         }
         saveRoutes()
 
         // Matrix sources
         if preset.mixerSources.count == 18 {
             for ch in 0..<18 {
-                guard let src = SignalSource(rawValue: preset.mixerSources[ch]) else { continue }
-                mixerSources[ch] = src
-                writeAsync { try? dev.setMixerSource(channel: ch, source: src) }
+                let byte = preset.mixerSources[ch]
+                mixerSources[ch] = byte
+                writeAsync { try? dev.setMixerSourceByte(channel: ch, sourceByte: byte) }
             }
         }
 
@@ -1063,23 +1080,24 @@ final class MixerState {
         // pushing cells so `effectiveGain` sees the right state.
         if preset.mixerMutes.count == 18 { mixerMutes = preset.mixerMutes }
         if preset.mixerSolos.count == 18 { mixerSolos = preset.mixerSolos }
-        if preset.mixerLevels.count == 18, preset.mixerLevels.allSatisfy({ $0.count == 3 }) {
-            mixerLevels = preset.mixerLevels
+        if preset.mixerLevels.count == 18, preset.mixerLevels.allSatisfy({ $0.count >= 3 }) {
+            mixerLevels = preset.mixerLevels.map { $0 + Array(repeating: 0, count: max(0, 4 - $0.count)) }
         }
-        if preset.mixerPans.count == 18, preset.mixerPans.allSatisfy({ $0.count == 3 }) {
-            mixerPans = preset.mixerPans
+        if preset.mixerPans.count == 18, preset.mixerPans.allSatisfy({ $0.count >= 3 }) {
+            mixerPans = preset.mixerPans.map { $0 + Array(repeating: 0, count: max(0, 4 - $0.count)) }
         }
         if preset.mixerNames.count == 18 { mixerNames = preset.mixerNames }
         linkedPairs = Set(preset.linkedLefts)
 
+        guard let p = device?.profile else { return }
         for ch in 0..<18 {
-            for bus in MixBus.matrixOutputs {
-                pushCellGain(channel: ch, bus: bus)
+            for bus in 0..<p.mixBusCount {
+                pushCellGainRaw(channel: ch, busIndex: bus)
             }
         }
 
-        if preset.selectedBus < UInt8(MixBus.matrixOutputs.count) {
-            selectedBus = MixBus.matrixOutputs[Int(preset.selectedBus)]
+        if preset.selectedBus < UInt8(p.mixBusCount) {
+            selectedBusIndex = Int(preset.selectedBus)
         }
 
         saveMatrix()
@@ -1099,19 +1117,19 @@ final class MixerState {
             name: name,
             createdAt: Date(),
             routes: Dictionary(uniqueKeysWithValues:
-                routes.map { ($0.key.rawValue, $0.value.rawValue) }),
-            mixerSources: mixerSources.map { $0.rawValue },
+                routes.map { (UInt16($0.key), $0.value) }),
+            mixerSources: mixerSources,
             mixerLevels: mixerLevels,
             mixerPans: mixerPans,
             mixerMutes: mixerMutes,
             mixerSolos: mixerSolos,
             mixerNames: mixerNames,
             linkedLefts: Array(linkedPairs),
-            selectedBus: UInt8(selectedBus.matrixIndex ?? 0)
+            selectedBus: UInt8(selectedBusIndex)
         )
     }
 
-    /// Export the current state to a `.8i6` file at the given URL.  The file
+    /// Export the current state to a snapshot file at the given URL.  The file
     /// format is JSON-encoded `ScarlettPreset` for cross-compatibility with
     /// the in-app preset list (you can save a file, then load it back as a
     /// preset and vice versa).
@@ -1124,7 +1142,7 @@ final class MixerState {
         logEvent(.info, "Export", "Exported snapshot to \(url.lastPathComponent)")
     }
 
-    /// Import a `.8i6` snapshot file from the given URL and apply it
+    /// Import a snapshot file from the given URL and apply it
     /// (routes + matrix + sources) the same way `userLoadPreset` does.
     func userImportSnapshot(from url: URL) throws {
         let data = try Data(contentsOf: url)
@@ -1145,56 +1163,75 @@ final class MixerState {
     ///   the matrix if the user wants to.
     /// Hardware switches (impedance / hi-lo), clock, sample rate and master
     /// output attenuation are left alone.
+    /// Push default routes (Monitor + Phones ← Mix M1) to the device.
+    /// Called on every connect so the new routing takes effect regardless
+    /// of old UserDefaults or flash state.
+    func pushDefaultRoutes() {
+        guard let dev = device else { return }
+        let mixBuses = dev.profile.mixBusSources
+        let m1 = mixBuses.count > 0 ? mixBuses[0].byte : 0xff
+        let m2 = mixBuses.count > 1 ? mixBuses[1].byte : m1
+        for output in dev.profile.physicalOutputs {
+            let src: UInt8 = output.isLeft ? m1 : m2
+            routes[Int(output.wValue)] = src
+            writeAsync { try? dev.setPhysicalRouteSource(output, sourceByte: src) }
+        }
+        saveRoutes()
+    }
+
+    /// Push all output attenuators to 0 dB (unity gain).  Called on every
+    /// connect because the device's flash may have atten at -inf from a
+    /// previous session with MixControl or a factory reset.
+    func pushDefaultAttenuation() {
+        // Temporarily disabled — the 18i8 firmware brute-force was
+        // disconnecting USB.  The device's factory flash may already
+        // have output atten at 0 dB.  Revisit after probing the correct
+        // register address for the 18i8's phones output.
+    }
+
     func userResetRoutingAndMatrix() {
-        let defaultRoutes: [(Route, MixBus)] = [
-            (.monitorLeft,  .daw1),
-            (.monitorRight, .daw2),
-            (.phonesLeft,   .daw1),
-            (.phonesRight,  .daw2),
-            (.spdifLeft,    .off),
-            (.spdifRight,   .off),
-        ]
-        for (route, source) in defaultRoutes {
-            routes[route] = source
-            if let dev = device {
-                writeAsync { try? dev.setRouteSource(route, from: source) }
-            }
+        guard let dev = device else { return }
+        let mixBuses = dev.profile.mixBusSources
+        let m1 = mixBuses.count > 0 ? mixBuses[0].byte : 0xff
+        let m2 = mixBuses.count > 1 ? mixBuses[1].byte : m1
+        for output in dev.profile.physicalOutputs {
+            let src: UInt8 = output.isLeft ? m1 : m2
+            routes[Int(output.wValue)] = src
+            writeAsync { try? dev.setPhysicalRouteSource(output, sourceByte: src) }
         }
         saveRoutes()
 
         // Reset matrix levels / pans / mutes / solos to defaults.
-        mixerLevels = Array(repeating: Array(repeating: 0, count: 3), count: 18)
-        mixerPans   = Array(repeating: Array(repeating: 0, count: 3), count: 18)
+        mixerLevels = Array(repeating: Array(repeating: 0, count: 4), count: 18)
+        mixerPans   = Array(repeating: Array(repeating: 0, count: 4), count: 18)
         mixerMutes  = Array(repeating: false, count: 18)
         mixerSolos  = Array(repeating: false, count: 18)
         linkedPairs = []
 
-        // Reset matrix sources to a sensible default: Ch 1..4 → Analog 1..4,
-        // Ch 5..6 → S/PDIF 1..2, Ch 7..13 → Off, Ch 14..15 reserved for the
-        // pinned DAW return (set below).  We disconnect every channel first
-        // (set to .off on the device) so the disconnect-first rule doesn't
-        // bite when we reassign the analog/spdif inputs.
-        let defaultSources: [SignalSource] = [
-            .analog1, .analog2, .analog3, .analog4,    // 0..3
-            .spdif1,  .spdif2,                          // 4..5
-            .off, .off, .off, .off, .off, .off, .off, .off,  // 6..13
-            .off, .off,                                 // 14..15 (pinned DAW assigns these)
-            .off, .off,                                 // 16..17
-        ]
+        // Reset matrix sources to a sensible default: wires profile's first
+        // few analog + digital sources to the first 6 matrix channels.
         // First pass: clear everything on the device so reassignment can't
         // hit the firmware's "source already wired" silent rejection.
         for ch in 0..<18 {
-            mixerSources[ch] = .off
+            mixerSources[ch] = 0xff  // Off byte
             if let dev = device {
-                writeAsync { try? dev.setMixerSource(channel: ch, source: .off) }
+                writeAsync { try? dev.setMixerSourceByte(channel: ch, sourceByte: 0xff) }
             }
         }
-        // Second pass: assign the real defaults for ch 0..5.
+        // Second pass: assign the real defaults using source bytes from the
+        // connected profile (or a reasonable fallback for 8i6).
+        let p = device?.profile ?? .scarlett8i6
+        let defaultBytes: [UInt8] = {
+            let analogs = p.sources.filter { $0.category == .analog }.prefix(4).map(\.byte)
+            let digitals = p.sources.filter { $0.category == .digital }.prefix(2).map(\.byte)
+            let offs = [UInt8](repeating: 0xff, count: 12)
+            return Array((analogs + digitals + offs).prefix(18))
+        }()
         for ch in 0..<6 {
-            let src = defaultSources[ch]
-            mixerSources[ch] = src
-            if let dev = device, src != .off {
-                writeAsync { try? dev.setMixerSource(channel: ch, source: src) }
+            let byte = defaultBytes[ch]
+            mixerSources[ch] = byte
+            if byte != 0xff, let dev = device {
+                writeAsync { try? dev.setMixerSourceByte(channel: ch, sourceByte: byte) }
             }
         }
 
@@ -1203,21 +1240,24 @@ final class MixerState {
 
         // Push every cell to the device with the new state.
         for ch in 0..<18 {
-            for bus in MixBus.matrixOutputs {
-                pushCellGain(channel: ch, bus: bus)
+            for bus in 0..<p.mixBusCount {
+                pushCellGainRaw(channel: ch, busIndex: bus)
             }
         }
 
-        // Capture routes back to factory: 1..4 = Analog, 5..6 = S/PDIF.
-        let defaultCaptureRoutes: [(Int, MixBus)] = [
-            (0, .analog1), (1, .analog2), (2, .analog3), (3, .analog4),
-            (4, .spdif1),  (5, .spdif2),
-        ]
+        // Capture routes back to factory: first 4 analog + first 2 digital.
         captureRoutes.removeAll(keepingCapacity: true)
-        for (ch, src) in defaultCaptureRoutes {
-            captureRoutes[ch] = src
-            if let dev = device {
-                writeAsync { try? dev.setCaptureRoute(channel: ch, from: src) }
+        let capAnalogs = p.sources.filter { $0.category == .analog }.prefix(4)
+        let capDigitals = p.sources.filter { $0.category == .digital }.prefix(2)
+        for (ch, sd) in capAnalogs.enumerated() {
+            captureRoutes[ch] = sd.byte
+        }
+        for (ch, sd) in capDigitals.enumerated() {
+            captureRoutes[4 + ch] = sd.byte
+        }
+        if let dev = device {
+            for (ch, byte) in captureRoutes {
+                writeAsync { try? dev.setCaptureRouteSource(channel: ch, sourceByte: byte) }
             }
         }
         saveCaptureRoutes()
@@ -1228,7 +1268,7 @@ final class MixerState {
         }
 
         saveMatrix()
-        logEvent(.info, "Reset", "Default config applied (Monitor + Phones = DAW 1/2)")
+        logEvent(.info, "Reset", "Default config applied (outputs routed M1/M2 stereo)")
     }
 
     /// Set the channel-wide mute directly (no toggle, no link propagation).
@@ -1277,15 +1317,16 @@ final class MixerState {
     /// channel-wide field (mute / solo) changes — every bus this
     /// channel feeds needs the new effective gain.
     private func pushAllCells(forChannel channel: Int) {
-        for bus in MixBus.matrixOutputs {
-            pushCellGain(channel: channel, bus: bus)
+        guard let p = device?.profile else { return }
+        for bus in 0..<p.mixBusCount {
+            pushCellGainRaw(channel: channel, busIndex: bus)
         }
     }
 
-    private func pushCellGain(channel: Int, bus: MixBus) {
-        guard let dev = device, let busIdx = bus.matrixIndex else { return }
-        let db = effectiveGain(channel: channel, busIdx: busIdx)
-        writeAsync { try? dev.setMixerGain(channel: channel, bus: bus, db: db) }
+    private func pushCellGainRaw(channel: Int, busIndex: Int) {
+        guard let dev = device else { return }
+        let db = effectiveGain(channel: channel, busIdx: busIndex)
+        writeAsync { try? dev.setMixerGainRaw(channel: channel, busIndex: busIndex, db: db) }
     }
 
     // MARK: - Copy mix to another bus
@@ -1296,13 +1337,11 @@ final class MixerState {
     /// source bus to the destination bus).  Useful for "make M3+M4 = M1+M2".
     ///
     /// `from` and `to` are the bus's stereo pair (0 = M1+M2, 1 = M3+M4,
-    /// 2 = M5+M6).  This works at the *pair* granularity because levels and
-    /// pans live per-pair; mute/solo are per-cell so both members of the
-    /// destination pair get updated.
+    /// 2 = M5+M6, 3 = M7+M8 on devices that have 8 buses).
     func userCopyMixPair(from sourcePair: Int, to destPair: Int) {
         guard sourcePair != destPair,
-              (0...2).contains(sourcePair),
-              (0...2).contains(destPair) else { return }
+              (0..<busPairCount).contains(sourcePair),
+              (0..<busPairCount).contains(destPair) else { return }
         // Mute and solo are now channel-wide, so copying a pair only
         // copies the per-pair level + pan into the destination.
         for ch in 0..<18 {

--- a/Sources/ScarlettApp/MixerState.swift
+++ b/Sources/ScarlettApp/MixerState.swift
@@ -160,7 +160,7 @@ final class MixerState {
         UserDefaults.standard.register(defaults: [
             "scarlett.autoBackupOnReset": true,
             "scarlett.autoBackupOnLaunch": false,
-            "scarlett.autoBackupOnQuit": false,
+            "scarlett.autoBackupOnQuit": true,
         ])
         installCoreAudioListener()
         attemptConnect()
@@ -214,8 +214,12 @@ final class MixerState {
             refreshFromDevice()
             loadPersistedState()
             ensurePinnedDawChannels()
-            // Push default routes so Mix M1 routing takes effect.
-            pushDefaultRoutes()
+            // Only push default routes when nothing was persisted (first
+            // connect or fresh install).  Otherwise the user's saved routes
+            // from `loadPersistedState` above would be overwritten.
+            if routes.isEmpty {
+                pushDefaultRoutes()
+            }
             if !wasConnected {
                 logEvent(.info, "Connection",
                          "Connected to \(dev.profile.displayName) (firmware \(firmware), serial \(serial))")
@@ -1164,8 +1168,8 @@ final class MixerState {
     /// Hardware switches (impedance / hi-lo), clock, sample rate and master
     /// output attenuation are left alone.
     /// Push default routes (Monitor + Phones ← Mix M1) to the device.
-    /// Called on every connect so the new routing takes effect regardless
-    /// of old UserDefaults or flash state.
+    /// Called only on first connect so the new routing takes effect;
+    /// subsequent connects use the user's persisted routes.
     func pushDefaultRoutes() {
         guard let dev = device else { return }
         let mixBuses = dev.profile.mixBusSources

--- a/Sources/ScarlettApp/PinnedStrips.swift
+++ b/Sources/ScarlettApp/PinnedStrips.swift
@@ -49,7 +49,7 @@ struct PinnedDawStrip: View {
     }
 
     private var fader: some View {
-        let pair = MixerState.pairIndex(of: state.selectedBus)
+        let pair = state.selectedBusIndex / 2
         let level = state.mixerLevels[leftCh][pair]
         let isMuted = state.mixerMutes[leftCh]
 
@@ -66,12 +66,12 @@ struct PinnedDawStrip: View {
             }
 
             VStack(spacing: 1) {
-                StripMeter(state: state, source: .daw1, height: 220)
+                StripMeter(state: state, sourceByte: 0x00, height: StripLayout.faderHeight)
                 Text("L").font(.system(size: 8, design: .monospaced))
                     .foregroundStyle(Theme.textSecondary)
             }
             VStack(spacing: 1) {
-                StripMeter(state: state, source: .daw2, height: 220)
+                StripMeter(state: state, sourceByte: 0x01, height: StripLayout.faderHeight)
                 Text("R").font(.system(size: 8, design: .monospaced))
                     .foregroundStyle(Theme.textSecondary)
             }
@@ -88,10 +88,11 @@ struct PinnedDawStrip: View {
     }
 
     private var peakReadout: some View {
-        let peakL = StripMeter.level(from: state.peaksHeld, source: .daw1)
-        let peakR = StripMeter.level(from: state.peaksHeld, source: .daw2)
-        let maxL  = StripMeter.level(from: state.peaksMax,  source: .daw1)
-        let maxR  = StripMeter.level(from: state.peaksMax,  source: .daw2)
+        let profile = state.device?.profile ?? .scarlett8i6
+        let peakL = StripMeter.level(from: state.peaksHeld, byte: 0x00, profile: profile)
+        let peakR = StripMeter.level(from: state.peaksHeld, byte: 0x01, profile: profile)
+        let maxL  = StripMeter.level(from: state.peaksMax,  byte: 0x00, profile: profile)
+        let maxR  = StripMeter.level(from: state.peaksMax,  byte: 0x01, profile: profile)
         let peak = max(peakL, peakR)
         let max_ = max(maxL, maxR)
         return VStack(spacing: 1) {
@@ -99,8 +100,8 @@ struct PinnedDawStrip: View {
                 .font(.system(size: 9, design: .monospaced))
                 .foregroundStyle(Theme.textSecondary)
             Button {
-                state.clearMaxPeak(forSource: .daw1)
-                state.clearMaxPeak(forSource: .daw2)
+                state.clearMaxPeak(forByte: 0x00)
+                state.clearMaxPeak(forByte: 0x01)
             } label: {
                 Text(formatPeak("Mx", max_))
                     .font(.system(size: 9, design: .monospaced))
@@ -156,8 +157,8 @@ struct PinnedMasterStrip: View {
                     get: { state.monitorAtten },
                     set: { state.userSetMonitorAtten($0) }
                 ),
-                leftRoute: .monitorLeft,
-                rightRoute: .monitorRight,
+                leftWValue: 0,
+                rightWValue: 1,
                 leftMuted: state.monitorLMuted,
                 rightMuted: state.monitorRMuted,
                 toggleLeft: {
@@ -179,8 +180,8 @@ struct PinnedMasterStrip: View {
                     get: { state.phonesAtten },
                     set: { state.userSetPhonesAtten($0) }
                 ),
-                leftRoute: .phonesLeft,
-                rightRoute: .phonesRight,
+                leftWValue: 2,
+                rightWValue: 3,
                 leftMuted: state.phonesLMuted,
                 rightMuted: state.phonesRMuted,
                 toggleLeft: {
@@ -208,10 +209,10 @@ struct OutputStrip: View {
     let title: String
     let subtitle: String
     @Binding var atten: Double
-    /// The Route enum cases for this strip's L and R outputs.  Used to
-    /// look up the current source via `state.routes[leftRoute]`.
-    let leftRoute: Route
-    let rightRoute: Route
+    /// The wValue for this strip's L and R outputs.  Used to
+    /// look up the current source via `state.routes[leftWValue]`.
+    let leftWValue: Int
+    let rightWValue: Int
     let leftMuted: Bool
     let rightMuted: Bool
     let toggleLeft: () -> Void
@@ -220,10 +221,10 @@ struct OutputStrip: View {
     let dimActive: Bool
     let toggleDim: () -> Void
 
-    /// Source feeding the L/R output right now (per the router).
-    /// Defaults to .off when no route has been set yet.
-    private var leftSource:  MixBus { state.routes[leftRoute]  ?? .off }
-    private var rightSource: MixBus { state.routes[rightRoute] ?? .off }
+    /// Source byte feeding the L/R output right now (per the router).
+    /// Defaults to 0xff (Off) when no route has been set yet.
+    private var leftSourceByte:  UInt8 { state.routes[leftWValue]  ?? 0xff }
+    private var rightSourceByte: UInt8 { state.routes[rightWValue] ?? 0xff }
 
     var body: some View {
         VStack(spacing: StripLayout.vSpacing) {
@@ -264,8 +265,8 @@ struct OutputStrip: View {
             VerticalFader(db: $atten, dbRange: -60...0)
                 .contextMenu { Button("Reset to 0 dB") { atten = 0 } }
 
-            RoutedMeter(state: state, source: leftSource)
-            RoutedMeter(state: state, source: rightSource)
+            RoutedMeter(state: state, sourceByte: leftSourceByte)
+            RoutedMeter(state: state, sourceByte: rightSourceByte)
 
             DbScale(
                 dbRange: -60...0,
@@ -283,10 +284,11 @@ struct OutputStrip: View {
 
     /// Pk / Mx based on the louder of the two currently-routed sources.
     private var peakReadout: some View {
-        let peakL = RoutedMeter.level(from: state.peaksHeld, source: leftSource)
-        let peakR = RoutedMeter.level(from: state.peaksHeld, source: rightSource)
-        let maxL  = RoutedMeter.level(from: state.peaksMax,  source: leftSource)
-        let maxR  = RoutedMeter.level(from: state.peaksMax,  source: rightSource)
+        let profile = state.device?.profile ?? .scarlett8i6
+        let peakL = RoutedMeter.level(from: state.peaksHeld, byte: leftSourceByte, profile: profile)
+        let peakR = RoutedMeter.level(from: state.peaksHeld, byte: rightSourceByte, profile: profile)
+        let maxL  = RoutedMeter.level(from: state.peaksMax,  byte: leftSourceByte, profile: profile)
+        let maxR  = RoutedMeter.level(from: state.peaksMax,  byte: rightSourceByte, profile: profile)
         let peak = max(peakL, peakR)
         let max_ = max(maxL, maxR)
         return VStack(spacing: 1) {
@@ -294,8 +296,8 @@ struct OutputStrip: View {
                 .font(.system(size: 9, design: .monospaced))
                 .foregroundStyle(Theme.textSecondary)
             Button {
-                state.clearMaxPeak(leftSource)
-                state.clearMaxPeak(rightSource)
+                state.clearMaxPeak(forByte: leftSourceByte)
+                state.clearMaxPeak(forByte: rightSourceByte)
             } label: {
                 Text(formatPeak("Mx", max_))
                     .font(.system(size: 9, design: .monospaced))
@@ -338,17 +340,18 @@ struct OutputStrip: View {
 /// little widget, not the whole output strip.
 struct RoutedMeter: View {
     @Bindable var state: MixerState
-    let source: MixBus
-    var height: CGFloat = 220
+    let sourceByte: UInt8
+    var height: CGFloat = StripLayout.faderHeight
 
     var body: some View {
-        let live = Self.level(from: state.peaks,    source: source)
-        let held = Self.level(from: state.peaksHeld, source: source)
-        let max_ = Self.level(from: state.peaksMax,  source: source)
+        let profile = state.device?.profile ?? .scarlett8i6
+        let live = Self.level(from: state.peaks,    byte: sourceByte, profile: profile)
+        let held = Self.level(from: state.peaksHeld, byte: sourceByte, profile: profile)
+        let max_ = Self.level(from: state.peaksMax,  byte: sourceByte, profile: profile)
         VerticalMeter(db: live, peakDb: held, maxPeakDb: max_, height: height)
     }
 
-    static func level(from reading: PeakReading, source: MixBus) -> Double {
-        reading.level(for: source)
+    static func level(from reading: PeakReading, byte: UInt8, profile: DeviceProfile) -> Double {
+        reading.level(forByte: byte, profile: profile)
     }
 }

--- a/Sources/ScarlettApp/PresetsView.swift
+++ b/Sources/ScarlettApp/PresetsView.swift
@@ -5,6 +5,15 @@ struct PresetsView: View {
     @Bindable var state: MixerState
     @State private var newPresetName: String = ""
     @State private var confirmDelete: ScarlettPreset?
+    @State private var renamingPresetID: UUID?
+    @State private var renameText: String = ""
+
+    @AppStorage("scarlett.autoBackupOnReset")
+    private var autoBackupOnReset: Bool = true
+    @AppStorage("scarlett.autoBackupOnLaunch")
+    private var autoBackupOnLaunch: Bool = false
+    @AppStorage("scarlett.autoBackupOnQuit")
+    private var autoBackupOnQuit: Bool = false
 
     private static let dateFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -13,10 +22,18 @@ struct PresetsView: View {
         return f
     }()
 
+    private static let backupFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return f
+    }()
+
+    /// The device profile name for labelling auto-backups, or nil if unknown.
+    private var profileLabel: String? {
+        state.device?.profile.displayName
+    }
+
     var body: some View {
-        // Preset save/load both touch the device (push routes + matrix), so
-        // when there's no device the page is gated the same way Mixer and
-        // Routing are.
         ConnectionOverlay(state: state) {
             presetsContent
         }
@@ -31,14 +48,43 @@ struct PresetsView: View {
                     Text("Captures: output routing, matrix sources / gains / mutes / solos, channel names, stereo-link state, and which bus is in view. Existing presets with the same name are overwritten.")
                         .font(.caption).foregroundStyle(Theme.textSecondary)
                 }
+
+                Panel(title: "Automatic backup") {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(spacing: 8) {
+                            Toggle("", isOn: $autoBackupOnLaunch)
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                                .labelsHidden()
+                            Text("On launch").font(.caption)
+                        }
+                        HStack(spacing: 8) {
+                            Toggle("", isOn: $autoBackupOnQuit)
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                                .labelsHidden()
+                            Text("On quit").font(.caption)
+                        }
+                        HStack(spacing: 8) {
+                            Toggle("", isOn: $autoBackupOnReset)
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                                .labelsHidden()
+                            Text("Before reset").font(.caption)
+                        }
+                    }
+                }
                 Panel(title: "Saved presets") {
-                    if state.presets.isEmpty {
-                        Text("No presets yet — save one above.")
-                            .font(.caption).foregroundStyle(Theme.textSecondary)
-                            .padding(.vertical, 6)
-                    } else {
-                        VStack(spacing: 4) {
-                            ForEach(state.presets.sorted(by: { $0.createdAt > $1.createdAt })) { preset in
+                    VStack(spacing: 4) {
+                        defaultPresetRow
+                        Divider().overlay(Theme.divider)
+                        let sorted = state.presets.sorted(by: { $0.createdAt > $1.createdAt })
+                        if sorted.isEmpty {
+                            Text("No presets yet — save one above.")
+                                .font(.caption).foregroundStyle(Theme.textSecondary)
+                                .padding(.vertical, 6)
+                        } else {
+                            ForEach(sorted) { preset in
                                 presetRow(preset)
                             }
                         }
@@ -71,7 +117,7 @@ struct PresetsView: View {
         HStack(alignment: .firstTextBaseline) {
             Text("Presets").font(.title2).bold().foregroundStyle(Theme.textPrimary)
             Spacer()
-            Text("\(state.presets.count) saved")
+            Text("\(state.presets.count + 1) saved")
                 .font(.caption).foregroundStyle(Theme.textSecondary)
         }
     }
@@ -113,12 +159,86 @@ struct PresetsView: View {
         newPresetName = ""
     }
 
-    private func presetRow(_ preset: ScarlettPreset) -> some View {
+    private var defaultPreset: ScarlettPreset {
+        ScarlettPreset(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!,
+            name: "Default",
+            createdAt: .distantPast,
+            routes: [:],
+            mixerSources: [],
+            mixerLevels: [],
+            mixerPans: [],
+            mixerMutes: [],
+            mixerSolos: [],
+            mixerNames: [],
+            linkedLefts: [],
+            selectedBus: 0
+        )
+    }
+
+    private var defaultPresetRow: some View {
         HStack(alignment: .center, spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
-                Text(preset.name).font(.subheadline.bold()).foregroundStyle(Theme.textPrimary)
-                Text(Self.dateFormatter.string(from: preset.createdAt))
+                Text("Default").font(.subheadline.bold()).foregroundStyle(Theme.textPrimary)
+                Text("Factory defaults — Monitor + Phones feed from Mix M1")
                     .font(.caption2).foregroundStyle(Theme.textSecondary)
+            }
+            Spacer()
+            Button {
+                applyDefault()
+            } label: {
+                Text("Reset")
+                    .font(.system(size: 11, weight: .semibold))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
+                    .background(Theme.muteActive)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(10)
+        .background(Theme.panelRaised)
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+    }
+
+    private func commitRename(_ preset: ScarlettPreset) {
+        let newName = renameText.trimmingCharacters(in: .whitespaces)
+        guard !newName.isEmpty, let idx = state.presets.firstIndex(where: { $0.id == preset.id }) else {
+            renamingPresetID = nil
+            return
+        }
+        var updated = preset
+        updated.name = newName
+        state.presets[idx] = updated
+        state.savePresets()
+        renamingPresetID = nil
+    }
+
+    private func applyDefault() {
+        if autoBackupOnReset {
+            let ts = Self.backupFormatter.string(from: Date())
+            let tag = profileLabel.map { "\($0) " } ?? ""
+            state.userSavePreset(name: "Backup \(tag)\(ts)")
+        }
+        state.userResetRoutingAndMatrix()
+    }
+
+    private func presetRow(_ preset: ScarlettPreset) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            if renamingPresetID == preset.id {
+                TextField("Preset name", text: $renameText)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: 200)
+                .onSubmit { commitRename(preset) }
+                .onExitCommand { renamingPresetID = nil }
+                .onAppear { renameText = preset.name }
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(preset.name).font(.subheadline.bold()).foregroundStyle(Theme.textPrimary)
+                    Text(Self.dateFormatter.string(from: preset.createdAt))
+                        .font(.caption2).foregroundStyle(Theme.textSecondary)
+                }
             }
             Spacer()
             Button {
@@ -133,6 +253,24 @@ struct PresetsView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 3))
             }
             .buttonStyle(.plain)
+
+            Button {
+                if renamingPresetID == preset.id {
+                    commitRename(preset)
+                } else {
+                    renameText = preset.name
+                    renamingPresetID = preset.id
+                }
+            } label: {
+                Image(systemName: "pencil")
+                    .font(.system(size: 11))
+                    .frame(width: 24, height: 22)
+                    .background(Theme.panelRaised)
+                    .foregroundStyle(Theme.textSecondary)
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+            .buttonStyle(.plain)
+            .help("Rename preset")
 
             Button {
                 confirmDelete = preset

--- a/Sources/ScarlettApp/ScarlettPreset.swift
+++ b/Sources/ScarlettApp/ScarlettPreset.swift
@@ -4,7 +4,7 @@ import ScarlettCore
 /// A complete snapshot of every user-controllable bit of state — exactly the
 /// stuff a person would want to recall as "my podcast setup" or "tracking
 /// drums today".  Persisted in UserDefaults (in-app preset list) and as
-/// `.8i6` JSON files via the File menu (Save snapshot / Open snapshot).
+/// `.8i6` snapshot files via the File menu (Save / Open).
 public struct ScarlettPreset: Codable, Identifiable, Hashable {
     public let id: UUID
     public var name: String
@@ -15,8 +15,8 @@ public struct ScarlettPreset: Codable, Identifiable, Hashable {
 
     /// Matrix mixer state (parallel to MixerState fields).
     public var mixerSources: [UInt8]    // 18 × SignalSource raw byte
-    public var mixerLevels:  [[Double]] // 18 × 3 (channel × bus-pair)
-    public var mixerPans:    [[Double]] // 18 × 3
+    public var mixerLevels:  [[Double]] // 18 × busPairCount
+    public var mixerPans:    [[Double]] // 18 × busPairCount
     public var mixerMutes:   [Bool]     // 18 (per-channel)
     public var mixerSolos:   [Bool]     // 18 (per-channel)
     public var mixerNames:   [String]   // 18
@@ -24,6 +24,6 @@ public struct ScarlettPreset: Codable, Identifiable, Hashable {
     /// Left-channel indices of linked stereo pairs.
     public var linkedLefts: [Int]
 
-    /// Index (0..5) of the bus that was active when the snapshot was taken.
+    /// Bus index (0..<mixBusCount) that was active when saved.
     public var selectedBus: UInt8
 }

--- a/Sources/ScarlettApp/Theme.swift
+++ b/Sources/ScarlettApp/Theme.swift
@@ -12,14 +12,15 @@ enum AppInfo {
 /// line up regardless of what content the section actually shows.
 enum StripLayout {
     static let width:               CGFloat = 100
-    static let headerHeight:        CGFloat = 50
-    static let switchRowHeight:     CGFloat = 22
-    static let panRowHeight:        CGFloat = 30
-    static let faderHeight:         CGFloat = 220
-    static let peakReadoutHeight:   CGFloat = 28
-    /// Bottom controls = single 22-pt row, contents centered.
-    static let controlsHeight:      CGFloat = 22
-    static let vSpacing:            CGFloat = 6
+    static let headerHeight:        CGFloat = 30
+    static let switchRowHeight:     CGFloat = 18
+    static let panRowHeight:        CGFloat = 22
+    static let faderHeight:         CGFloat = 100
+    static let peakReadoutHeight:   CGFloat = 22
+    /// Bottom controls = single 18-pt row, contents centered.
+    static let controlsHeight:      CGFloat = 18
+    static let vSpacing:            CGFloat = 4
+    static let rowPaddingV:         CGFloat = 6
 }
 
 // Centralised palette to keep the Control-2-style dark look consistent.

--- a/Sources/ScarlettApp/VerticalFader.swift
+++ b/Sources/ScarlettApp/VerticalFader.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// by `DbScale`, so the same coordinate math drives both.
 struct VerticalFader: View {
     @Binding var db: Double
-    var height: CGFloat = 220
+    var height: CGFloat = StripLayout.faderHeight
     var dbRange: ClosedRange<Double> = Self.defaultRange
 
     static let defaultRange: ClosedRange<Double> = -60...6
@@ -80,7 +80,7 @@ struct VerticalFader: View {
 
 /// Static dB-scale tick column rendered beside the fader.
 struct DbScale: View {
-    var height: CGFloat = 220
+    var height: CGFloat = StripLayout.faderHeight
     var dbRange: ClosedRange<Double> = VerticalFader.defaultRange
     var marks: [Int] = [0, -6, -12, -18, -24, -30, -36, -48, -60]
 
@@ -120,7 +120,7 @@ struct VerticalMeter: View {
     var db: Double
     var peakDb: Double = -.infinity
     var maxPeakDb: Double = -.infinity
-    var height: CGFloat = 220
+    var height: CGFloat = StripLayout.faderHeight
     private let dbMin: Double = -60
     private let dbMax: Double = 0
     private let width: CGFloat = 6

--- a/Sources/ScarlettCLI/main.swift
+++ b/Sources/ScarlettCLI/main.swift
@@ -157,6 +157,24 @@ usage: scarlett-cli <command> [args]
 
   save
       Persist current settings to device flash. Survives power cycle.
+
+  probe-18i8
+      One-shot raw dump for validating non-8i6 devices.  Reads peak
+      bytes at multiple lengths, dumps matrix/route/capture state raw,
+      and runs a SET→GET roundtrip on the matrix source picker.  Safe
+      for any connected 1st-gen Scarlett — uses raw control transfers,
+      no 8i6-specific enum assumptions.
+
+  probe-sources
+      Iterate every source byte 0x00..0x3F (plus 0xff) on the matrix
+      source picker, printing the SET→GET roundtrip for each.  Finds
+      hidden analog inputs and reveals which bytes the firmware treats
+      as valid source IDs vs gap memory.  Safe, read-only at end.
+
+  inspect
+      Read-only dump of current device state: matrix sources, matrix
+      gains, peaks, physical routes, attenuation.  Safe to run while
+      the GUI is connected — no writes, just diagnostics.
 """
 
 func main() throws {
@@ -338,6 +356,276 @@ func main() throws {
     case "save":
         try dev.saveSettingsToHardware()
         print("✓ settings persisted to device flash")
+
+    case "probe-sources":
+        // Iterate every byte 0x00-0x3F as a matrix source picker value.
+        // For each: SET → wait → GET → report.  The device's read-back
+        // reveals which bytes the firmware accepts as source IDs and which
+        // get transformed (e.g. 0xff → 0x22, certain high bytes → truncated).
+        // This is how we find hidden analog inputs (rear line jacks) on 18i8.
+        print("# probe-sources")
+        print("# profile=\(dev.profile.internalName) pid=0x\(String(format: "%04x", dev.profile.productID))")
+        print()
+        print("# SET each byte to ch0, one per 500ms, then single read at end")
+        let allBytes = Array(UInt8(0)...UInt8(0x3F)) + [UInt8(0xff)]
+        for (i, byte) in allBytes.enumerated() {
+            usleep(500_000)
+            try dev.controlOut(cmd: 0x01, value: 0x0600, index: 0x3200, data: [byte, 0])
+            if i % 8 == 7 || i == allBytes.count - 1 {
+                print("  \(String(format: "0x%02x", byte)) [\(i+1)/\(allBytes.count)]")
+            }
+        }
+        print("  ✓ all writes done, reading final state...")
+        usleep(500_000)
+        let r = try dev.controlIn(cmd: 0x01, value: 0x0600, index: 0x3200, length: 2)
+        print(String(format: "  ch0 final: 0x%02x 0x%02x", r[0], r[1]))
+        // Restore
+        try dev.controlOut(cmd: 0x01, value: 0x0600, index: 0x3200, data: [0xff, 0])
+
+    case "probe-18i8":
+        // Pure raw IO dump — no 8i6 enum assumptions.  Used for Phase 0
+        // validation of the 18i8 (Saffire18i8) byte tables.  All values
+        // read here are raw USB bytes; the agent interprets them offline.
+        let p = dev.profile
+        print("# probe-18i8")
+        print("# profile=\(p.internalName) pid=0x\(String(format: "%04x", p.productID)) display=\"\(p.displayName)\"")
+        print("# matrixInputCount=\(p.matrixInputCount) mixBusCount=\(p.mixBusCount)")
+        print("# captureChannelCount=\(p.captureChannelCount) loopbackChannelCount=\(p.loopbackChannelCount)")
+        print()
+
+        // 1. Raw peak bytes at multiple lengths for each of the 3 read groups.
+        print("## rawPeaks (cmd=0x03 index=0x3c00)")
+        for (label, wValue, length) in [
+            ("inputs", UInt16(0x0000), UInt16(36)),
+            ("inputs", UInt16(0x0000), UInt16(64)),
+            ("daw",     UInt16(0x0003), UInt16(12)),
+            ("daw",     UInt16(0x0003), UInt16(16)),
+            ("daw",     UInt16(0x0003), UInt16(32)),
+            ("mix",     UInt16(0x0001), UInt16(16)),
+            ("mix",     UInt16(0x0001), UInt16(32)),
+        ] as [(String, UInt16, UInt16)] {
+            let r = (try? dev.controlIn(cmd: 0x03, value: wValue, index: 0x3c00, length: length)) ?? []
+            let hex = r.map { String(format: "%02x", $0) }.joined(separator: " ")
+            print("  group=\(label.padding(toLength: 6, withPad: " ", startingAt: 0)) value=0x\(String(format: "%04x", wValue)) length=\(String(format: "%2d", length)) -> [\(hex)]")
+        }
+        print()
+
+        // 2. Matrix-mixer source reads, channel 0..<18 (we read raw 2 bytes).
+        print("## matrixSources (cmd=0x01 value=0x0600+ch index=0x3200 length=2)")
+        for ch in 0..<18 {
+            let r = (try? dev.controlIn(cmd: 0x01, value: 0x0600 + UInt16(ch), index: 0x3200, length: 2)) ?? []
+            let hex = r.count == 2 ? String(format: "%02x %02x", r[0], r[1]) : "<short>"
+            print("  ch\(String(format: "%02d", ch))  raw=[\(hex)]")
+        }
+        print()
+
+        // 3. Physical-output routes (wIndex 0x3300), probe wValues 0..<10 —
+        // covers 8i6's 6 and 18i8's 8 plus extra headroom.
+        print("## physicalRoutes (cmd=0x01 value=wValue index=0x3300 length=2)")
+        for wv in 0..<10 {
+            let r = (try? dev.controlIn(cmd: 0x01, value: UInt16(wv), index: 0x3300, length: 2)) ?? []
+            let hex = r.count == 2 ? String(format: "%02x %02x", r[0], r[1]) : "<short>"
+            print("  wValue=\(String(format: "%2d", wv))  raw=[\(hex)]")
+        }
+        print()
+
+        // 4. USB-capture routes (wIndex 0x3400), channels 0..<16 — covers
+        // 8i6's 6 + 18i8's 14 + 2 loopback plus headroom.
+        print("## captureRoutes (cmd=0x01 value=ch index=0x3400 length=2)")
+        for ch in 0..<16 {
+            let r = (try? dev.controlIn(cmd: 0x01, value: UInt16(ch), index: 0x3400, length: 2)) ?? []
+            let hex = r.count == 2 ? String(format: "%02x %02x", r[0], r[1]) : "<short>"
+            print("  ch\(String(format: "%02d", ch))  raw=[\(hex)]")
+        }
+        print()
+
+        // 5. Matrix-gain reads — channels 0..<6 × buses 0..<9 (ch << 3 masks
+        // bus to 3 bits, so bus0 and bus8 collapse on the wire — see if
+        // the device distinguishes them or returns the same data).
+        print("## matrixGains (cmd=0x01 value=0x0100+mtx index=0x3c00 length=2)")
+        for ch in 0..<6 {
+            for bus in 0..<9 {
+                let mtx = UInt16(ch << 3) + UInt16(bus & 0x07)
+                let r = (try? dev.controlIn(cmd: 0x01, value: 0x0100 + mtx, index: 0x3c00, length: 2)) ?? []
+                let hex = r.count == 2 ? String(format: "%02x %02x", r[0], r[1]) : "<short>"
+                print("  ch\(ch) bus\(bus) (mtx=0x\(String(format: "%02x", mtx)))  raw=[\(hex)]")
+            }
+        }
+        print()
+
+        // 6. setMixerSourceByte / getMixerSource roundtrip — write each known
+        // 18i8 source byte to channel 0 and read back.  Channel 0 is
+        // restored to Off (0xff) afterward so we don't disturb the state.
+        // This section uses the new typed-API setter (`setMixerSourceByte`)
+        // to exercise the Phase 1 write path on hardware.  The read stays
+        // as raw controlIn so we capture both bytes for the printout.
+        print("## sourceRoundtrip (channel 0, via setMixerSourceByte, then raw GET)")
+        let probes: [(UInt8, String)] = [
+            (0x08, "Anlg In 1"),
+            (0x10, "SPDIF L"),
+            (0x12, "ADAT In 1"),
+            (0x1a, "FromMix1"),
+            (0xff, "Off"),
+        ]
+        for (byte, name) in probes {
+            do {
+                try dev.setMixerSourceByte(channel: 0, sourceByte: byte)
+                usleep(30_000)
+                let r = (try? dev.controlIn(cmd: 0x01, value: 0x0600, index: 0x3200, length: 2)) ?? []
+                let hex = r.count == 2 ? String(format: "%02x %02x", r[0], r[1]) : "<short>"
+                print("  set(0x\(String(format: "%02x", byte)) = \(name.padding(toLength: 10, withPad: " ", startingAt: 0))) -> read=\(hex)")
+            } catch {
+                print("  set(0x\(String(format: "%02x", byte))) error: \(error)")
+            }
+        }
+        print()
+
+        // 7. typedApi — regression check that the new profile-driven typed
+        // getters (Phase 1 raw-byte API) return values consistent with the
+        // raw reads above.  Sets are skipped here to avoid disturbing state;
+        // we only read.
+        print("## typedApi (new raw-byte getters, read-only)")
+        if let firstMatrixByte = try? dev.getMixerSourceByte(channel: 0) {
+            print("  getMixerSourceByte(0)       -> 0x\(String(format: "%02x", firstMatrixByte))")
+        }
+        if let secondMatrixByte = try? dev.getMixerSourceByte(channel: 1) {
+            print("  getMixerSourceByte(1)       -> 0x\(String(format: "%02x", secondMatrixByte))")
+        }
+        if let gainCh0Bus0 = try? dev.getMixerGainRaw(channel: 0, busIndex: 0) {
+            print("  getMixerGainRaw(0, bus0)    -> \(String(format: "%.1f dB", gainCh0Bus0))")
+        }
+        if !p.physicalOutputs.isEmpty {
+            if let routeByte = try? dev.getPhysicalRouteSource(p.physicalOutputs[0]) {
+                print("  getPhysicalRouteSource(Mon.L wValue=\(p.physicalOutputs[0].wValue)) -> 0x\(String(format: "%02x", routeByte))")
+            }
+        }
+        if let capByte = try? dev.getCaptureRouteSource(channel: 0) {
+            print("  getCaptureRouteSource(0)    -> 0x\(String(format: "%02x", capByte))")
+        }
+        print()
+
+        // 8. Output attenuation registers — read every plausible wValue
+        // using both formula variants to find which register controls the
+        // 18i8's phones output.  Mute: value=0x0100+wv.  Atten: 0x0200+wv.
+        // Also try with +1 offset.
+        print("## outputAttenReads (wIndex=0x0a00, len=2)")
+        let attenBase = UInt16(0x0a00)
+        for label in ["mute", "atten"] {
+            let baseV = label == "mute" ? UInt16(0x0100) : UInt16(0x0200)
+            print("  # \(label) — value=\(String(format: "0x%04x", baseV))+wv → raw   (decoded)")
+            for wv in UInt16(0)..<UInt16(10) {
+                let val = baseV + wv
+                let r = (try? dev.controlIn(cmd: 0x01, value: val, index: attenBase, length: 2)) ?? [0, 0]
+                let raw = String(format: "%02x %02x", r[0], r[1])
+                let decoded: String
+                if label == "atten" {
+                    let raw16 = UInt16(r[0]) | (UInt16(r[1]) << 8)
+                    let db = Double(Int16(bitPattern: raw16)) / 256.0
+                    decoded = String(format: "%6.1f dB", db)
+                } else {
+                    decoded = r[0] == 0 ? "unmuted" : "muted"
+                }
+                print("    0x\(String(format: "%04x", val))  [\(raw)]  \(decoded)")
+            }
+            // Gentle SET→GET: write 0dB to wv=0, read back, then restore
+            let tv = baseV + 0
+            let orig = (try? dev.controlIn(cmd: 0x01, value: tv, index: attenBase, length: 2)) ?? [0, 0]
+            _ = try? dev.controlOut(cmd: 0x01, value: tv, index: attenBase, data: [0x00, 0x00])
+            usleep(40_000)
+            let after = (try? dev.controlIn(cmd: 0x01, value: tv, index: attenBase, length: 2)) ?? [0, 0]
+            print("    SET→GET test at 0x\(String(format: "%04x", tv)): orig=[\(String(format: "%02x %02x", orig[0], orig[1]))] → set=00 00 → read=[\(String(format: "%02x %02x", after[0], after[1]))]")
+            _ = try? dev.controlOut(cmd: 0x01, value: tv, index: attenBase, data: orig)
+        }
+
+        print()
+
+        // 8. Output gate register: wIndex=0x1400, read-only.
+        // Writes to this register return kIOUSBPipeStalled (0xe000404f) —
+        // the 18i8 firmware (like the 8i6) rejects writes at this index.
+        // The XML monset="1 1 1 1 1 1" configuration is applied by the
+        // original app at a different level (likely kernel/firmware init).
+        print("## outputGate reads (wIndex=0x1400 — read-only, writes stall)")
+        for pair in UInt16(1)...UInt16(5) {
+            let val = 0x0a00 + pair
+            let r = (try? dev.controlIn(cmd: 0x01, value: val, index: 0x1400, length: 1)) ?? [0]
+            print("  pair=\(pair) value=0x\(String(format: "%04x", val)) → [\(String(format: "%02x", r[0]))]")
+        }
+
+        // 10. (Direct route setup moved to section 1 — runs before reads.)
+
+        // 11. Clock sync status
+        let locked = (try? dev.getSyncLocked()) ?? false
+        print()
+        print("## clockSync")
+        print("  locked=\(locked)")
+
+        print()
+        // 12. Device identifiers
+        let fwBCD = dev.firmwareBCD() ?? 0
+        let fwStr = String(format: "0x%04x", fwBCD)
+        let sn = dev.serialNumber() ?? "?"
+        print("## device")
+        print("  bcdDevice(USB firmware)=\(fwStr)")
+        print("  serial=\(sn)")
+
+    case "inspect":
+        let p = dev.profile
+        print("# inspect")
+        print("# profile=\(p.internalName) pid=0x\(String(format: "%04x", p.productID))")
+        print()
+
+        print("## matrixSources")
+        for ch in 0..<p.matrixInputCount {
+            if let r = try? dev.controlIn(cmd: 0x01, value: 0x0600 + UInt16(ch), index: 0x3200, length: 2), r.count >= 2 {
+                let name = p.source(forByte: r[0]).displayName
+                print("  ch\(String(format: "%02d", ch)): 0x\(String(format: "%02x", r[0])) \(String(format: "%02x", r[1]))  (\(name))")
+            }
+        }
+        print()
+
+        print("## matrixGains (non-zero only)")
+        for ch in 0..<p.matrixInputCount {
+            for bus in 0..<p.mixBusCount {
+                if let db = try? dev.getMixerGainRaw(channel: ch, busIndex: bus), abs(db) > 0.5 {
+                    print("  ch\(ch)→M\(bus+1): \(String(format: "%.1f dB", db))")
+                }
+            }
+        }
+        print()
+
+        print("## peaks")
+        let peaks = (try? dev.readPeaks()) ?? .empty
+        print("  inputs: \(peaks.inputs.map { fmtDb($0) }.joined(separator: " "))")
+        print("  daw:    \(peaks.daw.map { fmtDb($0) }.joined(separator: " "))")
+        print("  mixer:  \(peaks.mixer.map { fmtDb($0) }.joined(separator: " "))")
+        print()
+
+        print("## physicalRoutes (wIndex=0x3300)")
+        for wv in 0..<p.physicalOutputs.count {
+            let out = p.physicalOutputs[wv]
+            if let r = try? dev.controlIn(cmd: 0x01, value: out.wValue, index: 0x3300, length: 2), r.count >= 2 {
+                let name = p.source(forByte: r[0]).displayName
+                print("  \(out.displayName) (wValue=\(out.wValue)): 0x\(String(format: "%02x", r[0])) (\(name))")
+            }
+        }
+        print()
+
+        print("## outputAtten (wIndex=0x0a00)")
+        for wv in 0..<p.physicalOutputs.count {
+            let out = p.physicalOutputs[wv]
+            do {
+                let mute = try dev.controlIn(cmd: 0x01, value: 0x0100 + out.wValue + 1, index: 0x0a00, length: 2)
+                let atten = try dev.controlIn(cmd: 0x01, value: 0x0200 + out.wValue + 1, index: 0x0a00, length: 2)
+                let raw16 = UInt16(atten[0]) | (UInt16(atten[1]) << 8)
+                let db = Double(Int16(bitPattern: raw16)) / 256.0
+                let isMuted = mute[0] != 0
+                print("  \(out.displayName): muted=\(isMuted ? "YES" : "no") atten=\(String(format: "%.1f dB", db))")
+            } catch {
+                print("  \(out.displayName): read error")
+            }
+        }
+        print()
+        print("  # End of inspect — run while GUI is connected for live state.")
 
     case "-h", "--help", "help":
         print(usage)

--- a/Sources/ScarlettCore/DeviceProfile.swift
+++ b/Sources/ScarlettCore/DeviceProfile.swift
@@ -8,8 +8,8 @@ import Foundation
 //   The 1st-gen Scarletts share the same control-transfer protocol family
 //   (cmd, wValue, wIndex semantics, matrix-cell addressing) but each
 //   model assigns *different bytes* to the same conceptual signal.  E.g.
-//   Mix M1 is byte 0x14 on the 8i6, 0x18 on the 18i6/18i8.  Likewise
-//   Analog 1 is 0x0c on the 8i6, 0x08 on the 18i6, 0x06 on the 18i8.
+//   Mix M1 is byte 0x14 on the 8i6, 0x18 on the 18i6, 0x1a on the 18i8.
+//   Analog 1 is 0x0c on the 8i6, 0x08 on the 18i6, 0x08 on the 18i8.
 //
 //   Hard-coding one device's bytes into an enum means we can't reuse the
 //   protocol layer for a sibling model.  A profile lets the protocol
@@ -34,6 +34,13 @@ public struct DeviceProfile: Sendable, Equatable {
     public let displayName: String
     /// True for everything we've not personally validated on hardware.
     public let isExperimental: Bool
+    /// Model name without generation suffix (e.g. "Scarlett 18i8").
+    public var modelName: String {
+        displayName.replacingOccurrences(
+            of: " \\(1st gen\\)$", with: "",
+            options: .regularExpression
+        ).trimmingCharacters(in: .whitespaces)
+    }
 
     // ---- Matrix mixer dimensions --------------------------------------
     /// Number of matrix input channels (rows).  18 on every model so far.
@@ -219,13 +226,14 @@ extension DeviceProfile {
         hasMonitorMono: false
     )
 
-    // ---- Scarlett 18i8 1st gen (USB24Tracker) — EXPERIMENTAL ----------
+    // ---- Scarlett 18i8 1st gen (Saffire18i8) — EXPERIMENTAL ----------
     //
-    // 4 analog (+ 4 line) + 2 S/PDIF + 8 ADAT + 8 DAW.  Matrix is 18 × 8.
+    // 8 analog + 2 S/PDIF + 8 ADAT + 8 DAW.  Matrix is 18 × 8.
     // 8 routable physical outputs (Monitor + Phones + Line 5/6 + S/PDIF).
+    // Source bytes from _Saffire18i8_IpSigTab (NOT _USB24Tracker — that's 16i8).
     public static let scarlett18i8 = DeviceProfile(
         productID: 0x8014,
-        internalName: "USB24Tracker",
+        internalName: "Saffire18i8",
         displayName: "Scarlett 18i8 (1st gen)",
         isExperimental: true,
         matrixInputCount: 18,
@@ -236,16 +244,20 @@ extension DeviceProfile {
             .init(byte: 0x09, displayName: "Analog 2",  category: .analog),
             .init(byte: 0x0a, displayName: "Analog 3",  category: .analog),
             .init(byte: 0x0b, displayName: "Analog 4",  category: .analog),
-            .init(byte: 0x0e, displayName: "S/PDIF L",  category: .digital),
-            .init(byte: 0x0f, displayName: "S/PDIF R",  category: .digital),
-            .init(byte: 0x10, displayName: "ADAT 1",    category: .digital),
-            .init(byte: 0x11, displayName: "ADAT 2",    category: .digital),
-            .init(byte: 0x12, displayName: "ADAT 3",    category: .digital),
-            .init(byte: 0x13, displayName: "ADAT 4",    category: .digital),
-            .init(byte: 0x14, displayName: "ADAT 5",    category: .digital),
-            .init(byte: 0x15, displayName: "ADAT 6",    category: .digital),
-            .init(byte: 0x16, displayName: "ADAT 7",    category: .digital),
-            .init(byte: 0x17, displayName: "ADAT 8",    category: .digital),
+            .init(byte: 0x0c, displayName: "Analog 5",  category: .analog),
+            .init(byte: 0x0d, displayName: "Analog 6",  category: .analog),
+            .init(byte: 0x0e, displayName: "Analog 7",  category: .analog),
+            .init(byte: 0x0f, displayName: "Analog 8",  category: .analog),
+            .init(byte: 0x10, displayName: "S/PDIF 1",  category: .digital),
+            .init(byte: 0x11, displayName: "S/PDIF 2",  category: .digital),
+            .init(byte: 0x12, displayName: "ADAT 1",    category: .digital),
+            .init(byte: 0x13, displayName: "ADAT 2",    category: .digital),
+            .init(byte: 0x14, displayName: "ADAT 3",    category: .digital),
+            .init(byte: 0x15, displayName: "ADAT 4",    category: .digital),
+            .init(byte: 0x16, displayName: "ADAT 5",    category: .digital),
+            .init(byte: 0x17, displayName: "ADAT 6",    category: .digital),
+            .init(byte: 0x18, displayName: "ADAT 7",    category: .digital),
+            .init(byte: 0x19, displayName: "ADAT 8",    category: .digital),
             .init(byte: 0x00, displayName: "DAW 1",     category: .daw),
             .init(byte: 0x01, displayName: "DAW 2",     category: .daw),
             .init(byte: 0x02, displayName: "DAW 3",     category: .daw),
@@ -254,27 +266,27 @@ extension DeviceProfile {
             .init(byte: 0x05, displayName: "DAW 6",     category: .daw),
             .init(byte: 0x06, displayName: "DAW 7",     category: .daw),
             .init(byte: 0x07, displayName: "DAW 8",     category: .daw),
-            .init(byte: 0x18, displayName: "Mix M1",    category: .mixOutput),
-            .init(byte: 0x19, displayName: "Mix M2",    category: .mixOutput),
-            .init(byte: 0x1a, displayName: "Mix M3",    category: .mixOutput),
-            .init(byte: 0x1b, displayName: "Mix M4",    category: .mixOutput),
-            .init(byte: 0x1c, displayName: "Mix M5",    category: .mixOutput),
-            .init(byte: 0x1d, displayName: "Mix M6",    category: .mixOutput),
-            .init(byte: 0x1e, displayName: "Mix M7",    category: .mixOutput),
-            .init(byte: 0x1f, displayName: "Mix M8",    category: .mixOutput),
+            .init(byte: 0x1a, displayName: "Mix M1",    category: .mixOutput),
+            .init(byte: 0x1b, displayName: "Mix M2",    category: .mixOutput),
+            .init(byte: 0x1c, displayName: "Mix M3",    category: .mixOutput),
+            .init(byte: 0x1d, displayName: "Mix M4",    category: .mixOutput),
+            .init(byte: 0x1e, displayName: "Mix M5",    category: .mixOutput),
+            .init(byte: 0x1f, displayName: "Mix M6",    category: .mixOutput),
+            .init(byte: 0x20, displayName: "Mix M7",    category: .mixOutput),
+            .init(byte: 0x21, displayName: "Mix M8",    category: .mixOutput),
         ],
         physicalOutputs: [
             .init(wValue: 0, displayName: "Monitor L",   pairLabel: "Monitor",  isLeft: true),
             .init(wValue: 1, displayName: "Monitor R",   pairLabel: "Monitor",  isLeft: false),
-            .init(wValue: 2, displayName: "Phones L",    pairLabel: "Phones",   isLeft: true),
-            .init(wValue: 3, displayName: "Phones R",    pairLabel: "Phones",   isLeft: false),
-            .init(wValue: 4, displayName: "Line Out 5",  pairLabel: "Line 5+6", isLeft: true),
-            .init(wValue: 5, displayName: "Line Out 6",  pairLabel: "Line 5+6", isLeft: false),
+            .init(wValue: 2, displayName: "HP 01 L",     pairLabel: "HP 01",    isLeft: true),
+            .init(wValue: 3, displayName: "HP 01 R",     pairLabel: "HP 01",    isLeft: false),
+            .init(wValue: 4, displayName: "HP 02 L",     pairLabel: "HP 02",    isLeft: true),
+            .init(wValue: 5, displayName: "HP 02 R",     pairLabel: "HP 02",    isLeft: false),
             .init(wValue: 6, displayName: "S/PDIF L",    pairLabel: "S/PDIF",   isLeft: true),
             .init(wValue: 7, displayName: "S/PDIF R",    pairLabel: "S/PDIF",   isLeft: false),
         ],
-        captureChannelCount: 14,
-        loopbackChannelCount: 2,
+        captureChannelCount: 18,
+        loopbackChannelCount: 0,
         impedanceChannels: [1, 2],
         hiLoChannels: [],
         hasMonitorMono: false
@@ -282,6 +294,12 @@ extension DeviceProfile {
 }
 
 // MARK: - Convenience accessors
+
+public enum PeakSlot: Sendable {
+    case input(Int)
+    case daw(Int)
+    case mixer(Int)
+}
 
 extension DeviceProfile {
     /// Look up a source by its wire byte (or fall back to Off).
@@ -300,5 +318,39 @@ extension DeviceProfile {
     /// All Mix M1..Mn entries in source order.  Used to populate router pickers.
     public var mixBusSources: [SourceDescriptor] {
         sources.filter { $0.category == .mixOutput }
+    }
+
+    /// Map a source byte to the peak meter slot that carries its level.
+    /// Peak indices are position-based, consistent across all 1st-gen devices:
+    ///   Analog N     → inputs[N-1]
+    ///   S/PDIF 1-2   → inputs[8,9]
+    ///   ADAT 1-8     → inputs[10..17]
+    ///   DAW 1-6      → daw[0..5]
+    ///   Mix M1-M8    → mixer[0..7]
+    public func peakSlot(forByte byte: UInt8) -> PeakSlot? {
+        let sd = source(forByte: byte)
+        switch sd.category {
+        case .analog:
+            let base = sources.filter({ $0.category == .analog }).first?.byte ?? 0
+            let idx = Int(byte) - Int(base)
+            if idx >= 0 && idx < 8 { return .input(idx) }
+        case .digital:
+            let adatBase = sources.filter({ $0.category == .digital && $0.displayName.starts(with: "ADAT") }).first?.byte
+            if let base = adatBase, byte >= base {
+                return .input(10 + Int(byte - base))
+            }
+            return .input(8 + Int(byte - 0x10))
+        case .daw:
+            let base = sources.filter({ $0.category == .daw }).first?.byte ?? 0
+            let idx = Int(byte) - Int(base)
+            if idx >= 0 && idx < 6 { return .daw(idx) }
+        case .mixOutput:
+            let base = sources.filter({ $0.category == .mixOutput }).first?.byte ?? 0
+            let idx = Int(byte) - Int(base)
+            if idx >= 0 && idx < 8 { return .mixer(idx) }
+        default:
+            break
+        }
+        return nil
     }
 }

--- a/Sources/ScarlettCore/ScarlettProtocol.swift
+++ b/Sources/ScarlettCore/ScarlettProtocol.swift
@@ -496,6 +496,144 @@ extension ScarlettDevice {
             mixer:  decodePeaks(mix, count: 8)
         )
     }
+
+    // MARK: - Profile-driven raw-byte commands
+    //
+    // Phase 1 of the multi-device refactor: every per-device byte / wIndex /
+    // wValue previously baked into the `SignalSource` / `MixBus` / `Route` /
+    // `SignalOut` enums now lives in `DeviceProfile`.  These methods take
+    // raw bytes and bus indices directly; call sites resolve them through
+    // `self.profile` (the active `DeviceProfile`).
+    //
+    // These are *additive* overloads — the 8i6-enum methods above remain so
+    // the existing `MixerState` / views still build.  Phase 2 will migrate
+    // those call sites to these raw-byte methods and remove the enums.
+    //
+    // Channel / bus / capture bounds are enforced against `profile`
+    // rather than baked into `0...17` / `m1..m6` / `0...7`.  `0xff`
+    // remains the "Off" *write* byte — but on the 18i8 the device reads
+    // back `0x22` after a `0xff` write (sentinel for "disconnected channel"),
+    // so callers must never compare a GET result to `0xff` to detect Off.
+    // Use `DeviceProfile.source(forByte:)` which falls back to "Off (0xXX)"
+    // for any byte not in `sources`.
+
+    /// Matrix-mixer source picker (`wIndex=0x3200`).
+    /// `channel` is 0..<profile.matrixInputCount.  `sourceByte` is one of
+    /// `profile.sources.map(\.byte)` (or `0xff` to disconnect).
+    public func setMixerSourceByte(channel: Int, sourceByte: UInt8) throws {
+        guard (0..<profile.matrixInputCount).contains(channel) else {
+            throw ScarlettError.invalidArgument("mixer channel must be 0..<\(profile.matrixInputCount)")
+        }
+        try controlOut(
+            cmd: 0x01,
+            value: 0x0600 + UInt16(channel),
+            index: 0x3200,
+            data: [sourceByte, 0x00]
+        )
+    }
+
+    public func getMixerSourceByte(channel: Int) throws -> UInt8 {
+        guard (0..<profile.matrixInputCount).contains(channel) else {
+            throw ScarlettError.invalidArgument("mixer channel must be 0..<\(profile.matrixInputCount)")
+        }
+        let r = try controlIn(cmd: 0x01, value: 0x0600 + UInt16(channel), index: 0x3200, length: 2)
+        return r[0]
+    }
+
+    /// Matrix-mixer per-cell gain (`wIndex=0x3c00`, `mtx=(channel<<3)|(bus&7)`).
+    /// `channel` is 0..<profile.matrixInputCount, `busIndex` is 0..<profile.mixBusCount.
+    /// The wire format masks the bus index to 3 bits, so `mixBusCount` is
+    /// limited to ≤ 8 regardless of device — see `18i8.md` (Phase 0 verdict).
+    public func setMixerGainRaw(channel: Int, busIndex: Int, db: Double) throws {
+        guard (0..<profile.matrixInputCount).contains(channel) else {
+            throw ScarlettError.invalidArgument("mixer channel must be 0..<\(profile.matrixInputCount)")
+        }
+        guard (0..<profile.mixBusCount).contains(busIndex) else {
+            throw ScarlettError.invalidArgument("mixer bus index must be 0..<\(profile.mixBusCount)")
+        }
+        let mtx = UInt16(channel << 3) + UInt16(busIndex & 0x07)
+        try controlOut(
+            cmd: 0x01,
+            value: 0x0100 + mtx,
+            index: 0x3c00,
+            data: gainBytes(db: db)
+        )
+    }
+
+    public func getMixerGainRaw(channel: Int, busIndex: Int) throws -> Double {
+        guard (0..<profile.matrixInputCount).contains(channel) else {
+            throw ScarlettError.invalidArgument("mixer channel must be 0..<\(profile.matrixInputCount)")
+        }
+        guard (0..<profile.mixBusCount).contains(busIndex) else {
+            throw ScarlettError.invalidArgument("mixer bus index must be 0..<\(profile.mixBusCount)")
+        }
+        let mtx = UInt16(channel << 3) + UInt16(busIndex & 0x07)
+        let r = try controlIn(cmd: 0x01, value: 0x0100 + mtx, index: 0x3c00, length: 2)
+        return Double(Int8(bitPattern: r[1]))
+    }
+
+    /// Physical-output source picker (`wIndex=0x3300`).
+    /// `output.wValue` comes from `profile.physicalOutputs`.
+    public func setPhysicalRouteSource(_ output: PhysicalOutput, sourceByte: UInt8) throws {
+        try controlOut(
+            cmd: 0x01,
+            value: output.wValue,
+            index: 0x3300,
+            data: [sourceByte, 0x00]
+        )
+    }
+
+    public func getPhysicalRouteSource(_ output: PhysicalOutput) throws -> UInt8 {
+        let r = try controlIn(cmd: 0x01, value: output.wValue, index: 0x3300, length: 2)
+        return r[0]
+    }
+
+    /// USB-capture (ToHost / DAW-input) source picker (`wIndex=0x3400`).
+    /// `channel` is 0..<profile.captureChannelCount + profile.loopbackChannelCount.
+    public func setCaptureRouteSource(channel: Int, sourceByte: UInt8) throws {
+        let upper = profile.captureChannelCount + profile.loopbackChannelCount
+        guard (0..<upper).contains(channel) else {
+            throw ScarlettError.invalidArgument("capture channel must be 0..<\(upper)")
+        }
+        try controlOut(
+            cmd: 0x01,
+            value: UInt16(channel),
+            index: 0x3400,
+            data: [sourceByte, 0x00]
+        )
+    }
+
+    public func getCaptureRouteSource(channel: Int) throws -> UInt8 {
+        let upper = profile.captureChannelCount + profile.loopbackChannelCount
+        guard (0..<upper).contains(channel) else {
+            throw ScarlettError.invalidArgument("capture channel must be 0..<\(upper)")
+        }
+        let r = try controlIn(cmd: 0x01, value: UInt16(channel), index: 0x3400, length: 2)
+        return r[0]
+    }
+
+    /// Post-DAC output mute/unmute for a physical output (by its wValue).
+    /// The wValue matches `PhysicalOutput.wValue` from the active profile.
+    /// Use this instead of `setMute(_:muted:)` which is tied to 8i6's
+    /// `SignalOut` enum mapping.
+    public func setMuteRaw(outputWValue: UInt16, muted: Bool) throws {
+        try controlOut(
+            cmd: 0x01,
+            value: 0x0100 + outputWValue + 1,
+            index: 0x0a00,
+            data: muted ? muteBytes : unmuteBytes
+        )
+    }
+
+    /// Post-DAC output attenuation for a physical output (by its wValue).
+    public func setAttenuationRaw(outputWValue: UInt16, db: Double) throws {
+        try controlOut(
+            cmd: 0x01,
+            value: 0x0200 + outputWValue + 1,
+            index: 0x0a00,
+            data: attenuationBytes(db: db)
+        )
+    }
 }
 
 func val16ToDb(_ v: UInt16) -> Double {

--- a/tooling/typecheck.sh
+++ b/tooling/typecheck.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# typecheck.sh — best-effort Swift verification on the Linux sandbox.
+#
+# The repo targets macOS only (imports IOKit / AppKit / SwiftUI, none of
+# which exist on Linux), so `swift build` cannot link ScarlettCore, let
+# alone ScarlettCLI or ScarlettApp.  What it CAN do:
+#
+#   1. `swiftc -parse <file>` — pure syntax check (catches brace mismatches,
+#      stray tokens, malformed statements).  Instant per file.
+#   2. `swift build --product scarlett-cli` — SwiftPM compiles each
+#      ScarlettCore source file individually.  Real type errors in the
+#      file body (typo'd method names, wrong arg counts, missing fields,
+#      bad pattern matches) surface before module emission fails on the
+#      `no such module 'IOKit'` line.  ScarlettCLI itself does NOT get
+#      typechecked (depends on ScarlettCore which can't emit) — verify
+#      those edits via `./tooling/run-mac.sh` on the Mac.
+#
+# Exit code: 0 if both steps clean (allowing for the known IOKit import
+# failure), 1 otherwise.
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# 1. Parse-check every Swift source in the repo.
+echo "→ swiftc -parse (per file)"
+parse_fail=0
+while IFS= read -r f; do
+  if ! swiftc -parse "$f" >/dev/null 2>&1; then
+    echo "  ✗ $f"
+    swiftc -parse "$f" >&2 || true
+    parse_fail=1
+  fi
+done < <(find Sources -name '*.swift' -type f | sort)
+if [[ $parse_fail -ne 0 ]]; then
+  exit 1
+fi
+echo "  ✓ all Swift sources parse cleanly"
+
+# 2. SwiftPM build of ScarlettCore (fails at module emission over IOKit —
+#    expected; we only care about body-level type errors).
+echo "→ swift build --product scarlett-cli"
+build_log="$(mktemp -t scarlett-build.XXXXXX.log)"
+trap 'rm -f "$build_log"' EXIT
+swift build --product scarlett-cli >"$build_log" 2>&1 || true
+
+# Filter out the known IOKit import error and check for anything else.
+real_errors="$(grep -E "error:" "$build_log" \
+    | grep -vE "no such module 'IOKit'" \
+    | grep -vE "emit-module command failed" || true)"
+if [[ -n "$real_errors" ]]; then
+  echo "  ✗ real type errors surfaced:"
+  echo "$real_errors" | sed 's/^/    /'
+  exit 1
+fi
+echo "  ✓ no real type errors (only the expected IOKit import failure remains)"
+exit 0


### PR DESCRIPTION
Howdy, thanks for starting this project. I've got an 18i8 and had a clanker slop out enough code to begin support. 

### Changes

When applied, this PR will:

* Add experimental Scarlett 18i8 support: byte tables, routing, matrix mixing, and DSP controls
* Generalize MixerState to derive channel counts, mix buses, and array sizing from the connected device profile instead of hardcoding 8i6 assumptions
* Split the mixer view into two rows to support the many inputs of the 18i8
* Add model metadata to snapshot files for cross-device preset safety
* Show model name in the UI and bypass the "unsupported device" overlay for 18i8
* Expand scarlett-cli with probe/control commands covering 18i8 registers
* Auto-pan stereo pairs (similar to the official Focusrite software)
* Push default routing only on first connect; preserve user's saved routes on reconnect
* Auto-backup on quit (default: on), reset (default: on), and launch (default: off)
* Derive reset defaults from the connected device profile instead of hardcoding 8i6 values
* Add profile-driven "Default" preset row for quick factory reset

###  Screenshots

<img width="2032" height="1162" alt="18i8-mixer" src="https://github.com/user-attachments/assets/9c1fbf18-6dff-416c-9541-7516011c3bff" />
<img width="2032" height="1162" alt="18i8-routing" src="https://github.com/user-attachments/assets/c6776eda-cbd5-44a7-8903-ca48d84dedd3" />
<img width="2032" height="1162" alt="18i8-presets" src="https://github.com/user-attachments/assets/b41c9ea5-f722-43c9-b512-accecf7ecd95" />
<img width="810" height="344" alt="18i8-about" src="https://github.com/user-attachments/assets/d5777d1d-d963-40e0-984c-6797015531fb" />


### Please Note
* Tested only on macOS 26 with a Scarlett 18i8
  * Please verify this didn't break 8i6 support or the UI on your end
* Checked output against a pair of headphones. I've _NOT_ confirmed Monitor out, MIDI, or SPDIF.
* Checked input against the front 4 XLR using a phantom-powered condenser mic, and the USB output from my Mac. I've _NOT_ confirmed Line Inputs 5-8, MIDI In, SPDIF, or Optical Input/ADAT.
* Drive-by PR. Seems to do the trick, but I'm not well-versed in Swift
  and don't have the bandwidth to support this long-term.
  

  