### PR TITLE
Enhance 18i8 support

### DIFF
--- a/Sources/ScarlettApp/ChannelStrip.swift
+++ b/Sources/ScarlettApp/ChannelStrip.swift
@@ -168,7 +168,7 @@ struct ChannelStrip: View {
 
             DbScale()
         }
-        .frame(height: 220)
+        .frame(height: StripLayout.faderHeight)
         .overlay(alignment: .topTrailing) {
             Text(formatDb(level))
                 .font(.system(size: 9, design: .monospaced))
@@ -276,7 +276,7 @@ struct StripMeter: View {
     @Bindable var state: MixerState
     let source: SignalSource
     let profile: DeviceProfile
-    var height: CGFloat = 220
+    var height: CGFloat = StripLayout.faderHeight
 
     var body: some View {
         let live = Self.level(from: state.peaks, source: source, profile: profile)

--- a/Sources/ScarlettApp/ContentView.swift
+++ b/Sources/ScarlettApp/ContentView.swift
@@ -71,6 +71,11 @@ struct ContentView: View {
             }
         }
         .preferredColorScheme(.dark)
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+            if UserDefaults.standard.bool(forKey: "scarlett.autoBackupOnQuit") {
+                state.userAutoSaveBackup(label: "at shutdown")
+            }
+        }
         .task { state.startMeterPolling() }
     }
 
@@ -113,7 +118,9 @@ struct ContentView: View {
         HStack {
             if !sidebarCollapsed {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(state.isConnected ? state.profile.displayName : "Scarlett MixControl")
+                    Text(state.isConnected
+                         ? state.profile.displayName.replacingOccurrences(of: " (1st gen)", with: "")
+                         : "Scarlett MixControl")
                         .font(.headline).foregroundStyle(Theme.textPrimary)
                     Text("1st Gen").font(.caption).foregroundStyle(Theme.textSecondary)
                 }

--- a/Sources/ScarlettApp/ContentView.swift
+++ b/Sources/ScarlettApp/ContentView.swift
@@ -73,7 +73,7 @@ struct ContentView: View {
         .preferredColorScheme(.dark)
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
             if UserDefaults.standard.bool(forKey: "scarlett.autoBackupOnQuit") {
-                state.userAutoSaveBackup(label: "at shutdown")
+                state.userAutoSaveBackup()
             }
         }
         .task { state.startMeterPolling() }

--- a/Sources/ScarlettApp/ContentView.swift
+++ b/Sources/ScarlettApp/ContentView.swift
@@ -119,7 +119,7 @@ struct ContentView: View {
             if !sidebarCollapsed {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(state.isConnected
-                         ? state.profile.displayName.replacingOccurrences(of: " (1st gen)", with: "")
+                         ? state.profile.shortDisplayName
                          : "Scarlett MixControl")
                         .font(.headline).foregroundStyle(Theme.textPrimary)
                     Text("1st Gen").font(.caption).foregroundStyle(Theme.textSecondary)
@@ -560,7 +560,7 @@ struct DeviceView: View {
                                     : a.displayName < b.displayName
                             }
                             ForEach(devices, id: \.productID) { p in
-                                let name = p.displayName.replacingOccurrences(of: " (1st gen)", with: "")
+                                let name = p.shortDisplayName
                                 compatRow(symbol: p.isExperimental ? "circle.dashed" : "checkmark.circle.fill",
                                           color: p.isExperimental ? .orange : .green,
                                           text: p.isExperimental
@@ -588,7 +588,7 @@ struct DeviceView: View {
         // fall back to the 8i6 (the primary target).
         let profile = state.device?.profile ?? .scarlett8i6
         return [
-            .init(label: "Model",        value: profile.displayName),
+            .init(label: "Model",        value: profile.shortDisplayName),
             .init(label: "Generation",   value: profile.isSupported
                   ? "1st Gen (supported)"
                   : "1st Gen — detected, not supported in this build"),

--- a/Sources/ScarlettApp/MatrixView.swift
+++ b/Sources/ScarlettApp/MatrixView.swift
@@ -115,14 +115,28 @@ struct MatrixMixerView: View {
     }
 
     private var strips: some View {
-        HStack(alignment: .top, spacing: 6) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 6) {
-                    ForEach(visibleChannels, id: \.self) { ch in
-                        ChannelStrip(channel: ch, state: state)
+        let ch = visibleChannels
+        let mid = ch.lowerBound + ch.count / 2
+        let topHalf = ch.lowerBound..<mid
+        let botHalf = mid..<ch.upperBound
+        return HStack(alignment: .top, spacing: 6) {
+            VStack(spacing: StripLayout.vSpacing) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(topHalf, id: \.self) { ch in
+                            ChannelStrip(channel: ch, state: state)
+                        }
                     }
+                    .padding(.vertical, StripLayout.rowPaddingV)
                 }
-                .padding(.vertical, 4)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(botHalf, id: \.self) { ch in
+                            ChannelStrip(channel: ch, state: state)
+                        }
+                    }
+                    .padding(.vertical, StripLayout.rowPaddingV)
+                }
             }
             PinnedDawStrip(state: state)
             PinnedMasterStrip(state: state)

--- a/Sources/ScarlettApp/MixerState.swift
+++ b/Sources/ScarlettApp/MixerState.swift
@@ -194,6 +194,7 @@ final class MixerState {
     @ObservationIgnored private let maxEvents = 100
     @ObservationIgnored private var coreAudioListenerInstalled = false
     @ObservationIgnored private var lastCoreAudioPresence: Bool = false
+    @ObservationIgnored private var didLaunchBackup = false
     var selectedBus: MixBus = .m1 {
         didSet {
             if !restoringProfileState { saveSelectedBus() }
@@ -201,12 +202,32 @@ final class MixerState {
     }
 
     init() {
+        UserDefaults.standard.register(defaults: [
+            "scarlett.autoBackupOnReset": true,
+            "scarlett.autoBackupOnLaunch": false,
+            "scarlett.autoBackupOnQuit": true,
+        ])
         installCoreAudioListener()
         // Defer USB work so the window can appear before we sync-read the
         // matrix (100+ control transfers when a device is connected).
         Task { @MainActor in
             attemptConnect()
         }
+    }
+
+    /// Formatter for auto-backup timestamps.
+    private static let backupFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return f
+    }()
+
+    /// Save a snapshot with a descriptive auto-backup label and the
+    /// current device profile name.
+    func userAutoSaveBackup(label: String) {
+        let ts = Self.backupFormatter.string(from: Date())
+        let tag = "\(profile.displayName) "
+        userSavePreset(name: "Auto-saved \(label) – \(tag)\(ts)")
     }
 
     /// Try to (re-)open the device and refresh all state.  Idempotent.
@@ -246,6 +267,13 @@ final class MixerState {
                          "Connected to \(dev.profile.displayName) (firmware \(firmware), serial \(serial))")
             }
             connection = .connected
+            if !didLaunchBackup {
+                didLaunchBackup = true
+                if UserDefaults.standard.bool(forKey: "scarlett.autoBackupOnLaunch") {
+                    userAutoSaveBackup(label: "at launch")
+                    logEvent(.info, "Backup", "Auto-saved launch snapshot")
+                }
+            }
         } catch ScarlettError.deviceNotFound {
             restoringProfileState = false
             self.device = nil
@@ -1045,8 +1073,20 @@ final class MixerState {
         let left = Self.leftOfPair(ch)
         if linkedPairs.contains(left) {
             linkedPairs.remove(left)
+            for pair in 0..<stereoPairCount {
+                mixerPans[left][pair] = 0
+                mixerPans[left + 1][pair] = 0
+                pushBusPair(channel: left, pair: pair)
+                pushBusPair(channel: left + 1, pair: pair)
+            }
         } else {
             linkedPairs.insert(left)
+            for pair in 0..<stereoPairCount {
+                mixerPans[left][pair] = -1
+                mixerPans[left + 1][pair] = 1
+                pushBusPair(channel: left, pair: pair)
+                pushBusPair(channel: left + 1, pair: pair)
+            }
         }
         saveMatrix()
     }
@@ -1072,6 +1112,10 @@ final class MixerState {
         let snapped = abs(pan) < 0.04 ? 0 : max(-1, min(1, pan))
         mixerPans[channel][pair] = snapped
         pushBusPair(channel: channel, pair: pair)
+        if let partner = linkedPartner(channel) {
+            mixerPans[partner][pair] = -snapped
+            pushBusPair(channel: partner, pair: pair)
+        }
         saveMatrix()
     }
 

--- a/Sources/ScarlettApp/MixerState.swift
+++ b/Sources/ScarlettApp/MixerState.swift
@@ -215,19 +215,12 @@ final class MixerState {
         }
     }
 
-    /// Formatter for auto-backup timestamps.
-    private static let backupFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return f
-    }()
-
-    /// Save a snapshot with a descriptive auto-backup label and the
-    /// current device profile name.
-    func userAutoSaveBackup(label: String) {
-        let ts = Self.backupFormatter.string(from: Date())
-        let tag = "\(profile.displayName) "
-        userSavePreset(name: "Auto-saved \(label) – \(tag)\(ts)")
+    /// Save a snapshot named "Auto Backup".  Because `userSavePreset`
+    /// overwrites same-named presets, each device keeps one rolling backup —
+    /// the list row already shows the timestamp and model, so the name stays
+    /// short and the preset list doesn't get cluttered.
+    func userAutoSaveBackup() {
+        userSavePreset(name: "Auto Backup")
     }
 
     /// Try to (re-)open the device and refresh all state.  Idempotent.
@@ -270,7 +263,7 @@ final class MixerState {
             if !didLaunchBackup {
                 didLaunchBackup = true
                 if UserDefaults.standard.bool(forKey: "scarlett.autoBackupOnLaunch") {
-                    userAutoSaveBackup(label: "at launch")
+                    userAutoSaveBackup()
                     logEvent(.info, "Backup", "Auto-saved launch snapshot")
                 }
             }
@@ -1341,6 +1334,11 @@ final class MixerState {
 
     func userDeletePreset(_ preset: ScarlettPreset) {
         presets.removeAll { $0.id == preset.id }
+        savePresets()
+    }
+
+    func userDeleteAllPresets() {
+        presets.removeAll()
         savePresets()
     }
 

--- a/Sources/ScarlettApp/MixerState.swift
+++ b/Sources/ScarlettApp/MixerState.swift
@@ -205,7 +205,7 @@ final class MixerState {
         UserDefaults.standard.register(defaults: [
             "scarlett.autoBackupOnReset": true,
             "scarlett.autoBackupOnLaunch": false,
-            "scarlett.autoBackupOnQuit": true,
+            "scarlett.autoBackupOnQuit": false,
         ])
         installCoreAudioListener()
         // Defer USB work so the window can appear before we sync-read the

--- a/Sources/ScarlettApp/MixerState.swift
+++ b/Sources/ScarlettApp/MixerState.swift
@@ -642,7 +642,7 @@ final class MixerState {
         }
     }
 
-    private func savePresets() {
+    func savePresets() {
         if let data = try? JSONEncoder().encode(presets) {
             UserDefaults.standard.set(data, forKey: Self.presetsKey)
         }

--- a/Sources/ScarlettApp/PinnedStrips.swift
+++ b/Sources/ScarlettApp/PinnedStrips.swift
@@ -67,12 +67,12 @@ struct PinnedDawStrip: View {
             }
 
             VStack(spacing: 1) {
-                StripMeter(state: state, source: .daw1, profile: state.profile, height: 220)
+                StripMeter(state: state, source: .daw1, profile: state.profile, height: StripLayout.faderHeight)
                 Text("L").font(.system(size: 8, design: .monospaced))
                     .foregroundStyle(Theme.textSecondary)
             }
             VStack(spacing: 1) {
-                StripMeter(state: state, source: .daw2, profile: state.profile, height: 220)
+                StripMeter(state: state, source: .daw2, profile: state.profile, height: StripLayout.faderHeight)
                 Text("R").font(.system(size: 8, design: .monospaced))
                     .foregroundStyle(Theme.textSecondary)
             }
@@ -342,7 +342,7 @@ struct RoutedMeter: View {
     @Bindable var state: MixerState
     let source: MixBus
     let profile: DeviceProfile
-    var height: CGFloat = 220
+    var height: CGFloat = StripLayout.faderHeight
 
     var body: some View {
         let live = Self.level(from: state.peaks,    source: source, profile: profile)

--- a/Sources/ScarlettApp/PresetsView.swift
+++ b/Sources/ScarlettApp/PresetsView.swift
@@ -7,6 +7,7 @@ struct PresetsView: View {
     @State private var newPresetName: String = ""
     @State private var confirmDelete: ScarlettPreset?
     @State private var loadErrorMessage: String?
+    @AppStorage("scarlett.autoBackupOnReset") private var autoBackupOnReset = true
 
     private static let dateFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -34,15 +35,17 @@ struct PresetsView: View {
                         .font(.caption).foregroundStyle(Theme.textSecondary)
                 }
                 Panel(title: "Saved presets") {
-                    if state.presets.isEmpty {
-                        Text("No presets yet — save one above.")
-                            .font(.caption).foregroundStyle(Theme.textSecondary)
-                            .padding(.vertical, 6)
-                    } else {
-                        VStack(spacing: 4) {
+                    VStack(spacing: 4) {
+                        defaultPresetRow
+                        if !state.presets.isEmpty {
+                            Divider().overlay(Theme.divider)
                             ForEach(state.presets.sorted(by: { $0.createdAt > $1.createdAt })) { preset in
                                 presetRow(preset)
                             }
+                        } else {
+                            Text("No presets yet — save one above.")
+                                .font(.caption).foregroundStyle(Theme.textSecondary)
+                                .padding(.vertical, 6)
                         }
                     }
                 }
@@ -170,5 +173,41 @@ struct PresetsView: View {
         .padding(10)
         .background(Theme.panelRaised)
         .clipShape(RoundedRectangle(cornerRadius: 5))
+    }
+
+    private var defaultPresetRow: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Default").font(.subheadline.bold()).foregroundStyle(Theme.textPrimary)
+                Text("Factory defaults for \(state.profile.displayName)")
+                    .font(.caption2).foregroundStyle(Theme.textSecondary)
+            }
+            Spacer()
+            Toggle("Backup first", isOn: $autoBackupOnReset)
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+            Button {
+                applyDefault()
+            } label: {
+                Text("Reset")
+                    .font(.system(size: 11, weight: .semibold))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
+                    .background(Theme.panelRaised)
+                    .foregroundStyle(Theme.textPrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(10)
+        .background(Theme.panelRaised)
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+    }
+
+    private func applyDefault() {
+        if autoBackupOnReset {
+            state.userAutoSaveBackup(label: "before reset")
+        }
+        state.userResetRoutingAndMatrix()
     }
 }

--- a/Sources/ScarlettApp/PresetsView.swift
+++ b/Sources/ScarlettApp/PresetsView.swift
@@ -6,6 +6,7 @@ struct PresetsView: View {
     @Bindable var state: MixerState
     @State private var newPresetName: String = ""
     @State private var confirmDelete: ScarlettPreset?
+    @State private var confirmDeleteAll = false
     @State private var loadErrorMessage: String?
     @State private var renamingPresetID: UUID?
     @State private var renameText: String = ""
@@ -38,34 +39,21 @@ struct PresetsView: View {
                         .font(.caption).foregroundStyle(Theme.textSecondary)
                 }
 
-                Panel(title: "Automatic backup") {
-                    VStack(alignment: .leading, spacing: 10) {
-                        HStack(spacing: 8) {
-                            Toggle("", isOn: $autoBackupOnLaunch)
-                                .toggleStyle(.switch)
-                                .controlSize(.small)
-                                .labelsHidden()
-                            Text("On launch").font(.caption)
-                        }
-                        HStack(spacing: 8) {
-                            Toggle("", isOn: $autoBackupOnQuit)
-                                .toggleStyle(.switch)
-                                .controlSize(.small)
-                                .labelsHidden()
-                            Text("On quit").font(.caption)
-                        }
-                        HStack(spacing: 8) {
-                            Toggle("", isOn: $autoBackupOnReset)
-                                .toggleStyle(.switch)
-                                .controlSize(.small)
-                                .labelsHidden()
-                            Text("Before reset").font(.caption)
-                        }
-                    }
-                }
-
                 Panel(title: "Saved presets") {
                     VStack(spacing: 4) {
+                        HStack(spacing: 16) {
+                            Text("Auto backup:").font(.caption).foregroundStyle(Theme.textSecondary)
+                            Toggle("On launch", isOn: $autoBackupOnLaunch).toggleStyle(.switch)
+                            Toggle("On quit", isOn: $autoBackupOnQuit).toggleStyle(.switch)
+                            Toggle("Before reset", isOn: $autoBackupOnReset).toggleStyle(.switch)
+                            Spacer()
+                            Button("Delete All", role: .destructive) {
+                                confirmDeleteAll = true
+                            }
+                            .disabled(state.presets.isEmpty)
+                            .help("Delete every saved preset")
+                        }
+                        Divider().overlay(Theme.divider).padding(.vertical, 6)
                         defaultPresetRow
                         if !state.presets.isEmpty {
                             Divider().overlay(Theme.divider)
@@ -83,6 +71,12 @@ struct PresetsView: View {
             .padding(24)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            // Clicking empty space in the presets area ends an in-progress
+            // rename (same as clicking anywhere else in the app).
+            commitCurrentRename()
+        }
         .background(Theme.background)
         .confirmationDialog(
             "Delete preset?",
@@ -99,6 +93,19 @@ struct PresetsView: View {
                 }
             }
             Button("Cancel", role: .cancel) { confirmDelete = nil }
+        }
+        .confirmationDialog(
+            "Delete all saved presets?",
+            isPresented: $confirmDeleteAll,
+            titleVisibility: .visible
+        ) {
+            Button("Delete All", role: .destructive) {
+                state.userDeleteAllPresets()
+                renamingPresetID = nil
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes every saved preset across all devices. The built-in Default reset is not affected.")
         }
         .alert(
             "Couldn't load preset",
@@ -159,6 +166,25 @@ struct PresetsView: View {
         newPresetName = ""
     }
 
+    /// Commit whatever rename is in progress (if any).  Used by the
+    /// click-anywhere-to-exit paths and before switching to a different row.
+    private func commitCurrentRename() {
+        guard let id = renamingPresetID,
+              let preset = state.presets.first(where: { $0.id == id }) else {
+            renamingPresetID = nil
+            return
+        }
+        commitRename(preset)
+    }
+
+    private func startRename(_ preset: ScarlettPreset) {
+        guard renamingPresetID != preset.id else { return }
+        // Don't silently discard an edit on another row when clicking this one.
+        commitCurrentRename()
+        renameText = preset.name
+        renamingPresetID = preset.id
+    }
+
     private func commitRename(_ preset: ScarlettPreset) {
         let newName = renameText.trimmingCharacters(in: .whitespaces)
         guard !newName.isEmpty, let idx = state.presets.firstIndex(where: { $0.id == preset.id }) else {
@@ -174,7 +200,7 @@ struct PresetsView: View {
 
     private func applyDefault() {
         if autoBackupOnReset {
-            state.userAutoSaveBackup(label: "before reset")
+            state.userAutoSaveBackup()
         }
         state.userResetRoutingAndMatrix()
     }
@@ -214,8 +240,10 @@ struct PresetsView: View {
                     .onSubmit { commitRename(preset) }
                     .onExitCommand { renamingPresetID = nil }
                     .onChange(of: nameFocused) { _, focused in
-                        // Clicking anywhere else commits the rename; Esc above
-                        // already cleared renamingPresetID so it won't double-commit.
+                        // Clicking anywhere else in the app commits the rename.
+                        // `renamingPresetID == preset.id` keeps this from firing
+                        // after we've already switched to another row's rename
+                        // (Esc / startRename clear it first).
                         if !focused, renamingPresetID == preset.id {
                             commitRename(preset)
                         }
@@ -252,24 +280,7 @@ struct PresetsView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 3))
             }
             .buttonStyle(.plain)
-
-            Button {
-                if renamingPresetID == preset.id {
-                    commitRename(preset)
-                } else {
-                    renameText = preset.name
-                    renamingPresetID = preset.id
-                }
-            } label: {
-                Image(systemName: "pencil")
-                    .font(.system(size: 11))
-                    .frame(width: 24, height: 22)
-                    .background(Theme.panelRaised)
-                    .foregroundStyle(Theme.textSecondary)
-                    .clipShape(RoundedRectangle(cornerRadius: 3))
-            }
-            .buttonStyle(.plain)
-            .help("Rename preset")
+            .help("Load preset")
 
             Button {
                 confirmDelete = preset
@@ -285,6 +296,11 @@ struct PresetsView: View {
             .help("Delete preset")
             .accessibilityLabel("Delete preset \(preset.name)")
         }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            startRename(preset)
+        }
+        .help("Click to rename")
         .padding(10)
         .background(Theme.panelRaised)
         .clipShape(RoundedRectangle(cornerRadius: 5))

--- a/Sources/ScarlettApp/PresetsView.swift
+++ b/Sources/ScarlettApp/PresetsView.swift
@@ -9,6 +9,7 @@ struct PresetsView: View {
     @State private var loadErrorMessage: String?
     @State private var renamingPresetID: UUID?
     @State private var renameText: String = ""
+    @FocusState private var nameFocused: Bool
 
     @AppStorage("scarlett.autoBackupOnReset")  private var autoBackupOnReset = true
     @AppStorage("scarlett.autoBackupOnLaunch") private var autoBackupOnLaunch = false
@@ -209,10 +210,15 @@ struct PresetsView: View {
             if renamingPresetID == preset.id {
                 TextField("Preset name", text: $renameText)
                     .textFieldStyle(.roundedBorder)
-                    .frame(maxWidth: 200)
+                    .focused($nameFocused)
                     .onSubmit { commitRename(preset) }
                     .onExitCommand { renamingPresetID = nil }
-                    .onAppear { renameText = preset.name }
+                    .onAppear {
+                        renameText = preset.name
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                            nameFocused = true
+                        }
+                    }
             } else {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(preset.name).font(.subheadline.bold()).foregroundStyle(Theme.textPrimary)

--- a/Sources/ScarlettApp/PresetsView.swift
+++ b/Sources/ScarlettApp/PresetsView.swift
@@ -7,7 +7,12 @@ struct PresetsView: View {
     @State private var newPresetName: String = ""
     @State private var confirmDelete: ScarlettPreset?
     @State private var loadErrorMessage: String?
-    @AppStorage("scarlett.autoBackupOnReset") private var autoBackupOnReset = true
+    @State private var renamingPresetID: UUID?
+    @State private var renameText: String = ""
+
+    @AppStorage("scarlett.autoBackupOnReset")  private var autoBackupOnReset = true
+    @AppStorage("scarlett.autoBackupOnLaunch") private var autoBackupOnLaunch = false
+    @AppStorage("scarlett.autoBackupOnQuit")   private var autoBackupOnQuit = false
 
     private static let dateFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -17,9 +22,6 @@ struct PresetsView: View {
     }()
 
     var body: some View {
-        // Preset save/load both touch the device (push routes + matrix), so
-        // when there's no device the page is gated the same way Mixer and
-        // Routing are.
         ConnectionOverlay(state: state) {
             presetsContent
         }
@@ -34,6 +36,33 @@ struct PresetsView: View {
                     Text("Captures: output routing, matrix sources / gains / mutes / solos, channel names, stereo-link state, and which bus is in view. Existing presets with the same name are overwritten.")
                         .font(.caption).foregroundStyle(Theme.textSecondary)
                 }
+
+                Panel(title: "Automatic backup") {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(spacing: 8) {
+                            Toggle("", isOn: $autoBackupOnLaunch)
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                                .labelsHidden()
+                            Text("On launch").font(.caption)
+                        }
+                        HStack(spacing: 8) {
+                            Toggle("", isOn: $autoBackupOnQuit)
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                                .labelsHidden()
+                            Text("On quit").font(.caption)
+                        }
+                        HStack(spacing: 8) {
+                            Toggle("", isOn: $autoBackupOnReset)
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                                .labelsHidden()
+                            Text("Before reset").font(.caption)
+                        }
+                    }
+                }
+
                 Panel(title: "Saved presets") {
                     VStack(spacing: 4) {
                         defaultPresetRow
@@ -71,7 +100,7 @@ struct PresetsView: View {
             Button("Cancel", role: .cancel) { confirmDelete = nil }
         }
         .alert(
-            "Couldn’t load preset",
+            "Couldn't load preset",
             isPresented: Binding(
                 get: { loadErrorMessage != nil },
                 set: { if !$0 { loadErrorMessage = nil } }
@@ -87,7 +116,7 @@ struct PresetsView: View {
         HStack(alignment: .firstTextBaseline) {
             Text("Presets").font(.title2).bold().foregroundStyle(Theme.textPrimary)
             Spacer()
-            Text("\(state.presets.count) saved")
+            Text("\(state.presets.count + 1) saved")
                 .font(.caption).foregroundStyle(Theme.textSecondary)
         }
     }
@@ -129,14 +158,69 @@ struct PresetsView: View {
         newPresetName = ""
     }
 
-    private func presetRow(_ preset: ScarlettPreset) -> some View {
+    private func commitRename(_ preset: ScarlettPreset) {
+        let newName = renameText.trimmingCharacters(in: .whitespaces)
+        guard !newName.isEmpty, let idx = state.presets.firstIndex(where: { $0.id == preset.id }) else {
+            renamingPresetID = nil
+            return
+        }
+        var updated = preset
+        updated.name = newName
+        state.presets[idx] = updated
+        state.savePresets()
+        renamingPresetID = nil
+    }
+
+    private func applyDefault() {
+        if autoBackupOnReset {
+            state.userAutoSaveBackup(label: "before reset")
+        }
+        state.userResetRoutingAndMatrix()
+    }
+
+    private var defaultPresetRow: some View {
         HStack(alignment: .center, spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
-                Text(preset.name).font(.subheadline.bold()).foregroundStyle(Theme.textPrimary)
-                Text(Self.dateFormatter.string(from: preset.createdAt))
+                Text("Default").font(.subheadline.bold()).foregroundStyle(Theme.textPrimary)
+                Text("Factory defaults for \(state.profile.displayName)")
                     .font(.caption2).foregroundStyle(Theme.textSecondary)
-                Text(state.presetDeviceLabel(preset))
-                    .font(.caption2).foregroundStyle(Theme.textSecondary)
+            }
+            Spacer()
+            Button {
+                applyDefault()
+            } label: {
+                Text("Reset")
+                    .font(.system(size: 11, weight: .semibold))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
+                    .background(Theme.muteActive)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(10)
+        .background(Theme.panelRaised)
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+    }
+
+    private func presetRow(_ preset: ScarlettPreset) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            if renamingPresetID == preset.id {
+                TextField("Preset name", text: $renameText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 200)
+                    .onSubmit { commitRename(preset) }
+                    .onExitCommand { renamingPresetID = nil }
+                    .onAppear { renameText = preset.name }
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(preset.name).font(.subheadline.bold()).foregroundStyle(Theme.textPrimary)
+                    Text(Self.dateFormatter.string(from: preset.createdAt))
+                        .font(.caption2).foregroundStyle(Theme.textSecondary)
+                    Text(state.presetDeviceLabel(preset))
+                        .font(.caption2).foregroundStyle(Theme.textSecondary)
+                }
             }
             Spacer()
             Button {
@@ -157,6 +241,24 @@ struct PresetsView: View {
             .buttonStyle(.plain)
 
             Button {
+                if renamingPresetID == preset.id {
+                    commitRename(preset)
+                } else {
+                    renameText = preset.name
+                    renamingPresetID = preset.id
+                }
+            } label: {
+                Image(systemName: "pencil")
+                    .font(.system(size: 11))
+                    .frame(width: 24, height: 22)
+                    .background(Theme.panelRaised)
+                    .foregroundStyle(Theme.textSecondary)
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+            .buttonStyle(.plain)
+            .help("Rename preset")
+
+            Button {
                 confirmDelete = preset
             } label: {
                 Image(systemName: "trash")
@@ -173,41 +275,5 @@ struct PresetsView: View {
         .padding(10)
         .background(Theme.panelRaised)
         .clipShape(RoundedRectangle(cornerRadius: 5))
-    }
-
-    private var defaultPresetRow: some View {
-        HStack(alignment: .center, spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Default").font(.subheadline.bold()).foregroundStyle(Theme.textPrimary)
-                Text("Factory defaults for \(state.profile.displayName)")
-                    .font(.caption2).foregroundStyle(Theme.textSecondary)
-            }
-            Spacer()
-            Toggle("Backup first", isOn: $autoBackupOnReset)
-                .toggleStyle(.switch)
-                .controlSize(.mini)
-            Button {
-                applyDefault()
-            } label: {
-                Text("Reset")
-                    .font(.system(size: 11, weight: .semibold))
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 5)
-                    .background(Theme.panelRaised)
-                    .foregroundStyle(Theme.textPrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: 3))
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(10)
-        .background(Theme.panelRaised)
-        .clipShape(RoundedRectangle(cornerRadius: 5))
-    }
-
-    private func applyDefault() {
-        if autoBackupOnReset {
-            state.userAutoSaveBackup(label: "before reset")
-        }
-        state.userResetRoutingAndMatrix()
     }
 }

--- a/Sources/ScarlettApp/PresetsView.swift
+++ b/Sources/ScarlettApp/PresetsView.swift
@@ -213,6 +213,13 @@ struct PresetsView: View {
                     .focused($nameFocused)
                     .onSubmit { commitRename(preset) }
                     .onExitCommand { renamingPresetID = nil }
+                    .onChange(of: nameFocused) { _, focused in
+                        // Clicking anywhere else commits the rename; Esc above
+                        // already cleared renamingPresetID so it won't double-commit.
+                        if !focused, renamingPresetID == preset.id {
+                            commitRename(preset)
+                        }
+                    }
                     .onAppear {
                         renameText = preset.name
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {

--- a/Sources/ScarlettApp/Theme.swift
+++ b/Sources/ScarlettApp/Theme.swift
@@ -15,14 +15,15 @@ enum AppInfo {
 /// line up regardless of what content the section actually shows.
 enum StripLayout {
     static let width:               CGFloat = 100
-    static let headerHeight:        CGFloat = 50
-    static let switchRowHeight:     CGFloat = 22
-    static let panRowHeight:        CGFloat = 30
-    static let faderHeight:         CGFloat = 220
-    static let peakReadoutHeight:   CGFloat = 28
-    /// Bottom controls = single 22-pt row, contents centered.
-    static let controlsHeight:      CGFloat = 22
-    static let vSpacing:            CGFloat = 6
+    static let headerHeight:        CGFloat = 30
+    static let switchRowHeight:     CGFloat = 18
+    static let panRowHeight:        CGFloat = 22
+    static let faderHeight:         CGFloat = 100
+    static let peakReadoutHeight:   CGFloat = 22
+    /// Bottom controls = single 18-pt row, contents centered.
+    static let controlsHeight:      CGFloat = 18
+    static let vSpacing:            CGFloat = 4
+    static let rowPaddingV:         CGFloat = 6
 }
 
 // Centralised palette to keep the Control-2-style dark look consistent.

--- a/Sources/ScarlettApp/VerticalFader.swift
+++ b/Sources/ScarlettApp/VerticalFader.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// by `DbScale`, so the same coordinate math drives both.
 struct VerticalFader: View {
     @Binding var db: Double
-    var height: CGFloat = 220
+    var height: CGFloat = StripLayout.faderHeight
     var dbRange: ClosedRange<Double> = Self.defaultRange
 
     static let defaultRange: ClosedRange<Double> = -60...6
@@ -80,7 +80,7 @@ struct VerticalFader: View {
 
 /// Static dB-scale tick column rendered beside the fader.
 struct DbScale: View {
-    var height: CGFloat = 220
+    var height: CGFloat = StripLayout.faderHeight
     var dbRange: ClosedRange<Double> = VerticalFader.defaultRange
     var marks: [Int] = [0, -6, -12, -18, -24, -30, -36, -48, -60]
 
@@ -120,7 +120,7 @@ struct VerticalMeter: View {
     var db: Double
     var peakDb: Double = -.infinity
     var maxPeakDb: Double = -.infinity
-    var height: CGFloat = 220
+    var height: CGFloat = StripLayout.faderHeight
     private let dbMin: Double = -60
     private let dbMax: Double = 0
     private let width: CGFloat = 6

--- a/Sources/ScarlettCore/DeviceProfile.swift
+++ b/Sources/ScarlettCore/DeviceProfile.swift
@@ -239,7 +239,7 @@ extension DeviceProfile {
     //
     // 8 analog + 2 S/PDIF + 8 ADAT + 8 DAW.  Matrix is 18 × 8.
     // Wire bytes verified against Linux `s18i8_info` in mixer_scarlett.c.
-    // 8 routable physical outputs (Monitor + Phones + Line 5/6 + S/PDIF).
+    // 8 routable physical outputs (Monitor + two headphone jacks + S/PDIF).
     public static let scarlett18i8 = DeviceProfile(
         productID: 0x8014,
         internalName: "USB24Tracker",
@@ -287,10 +287,10 @@ extension DeviceProfile {
         physicalOutputs: [
             .init(wValue: 0, displayName: "Monitor L",   pairLabel: "Monitor",  isLeft: true),
             .init(wValue: 1, displayName: "Monitor R",   pairLabel: "Monitor",  isLeft: false),
-            .init(wValue: 2, displayName: "Phones L",    pairLabel: "Phones",   isLeft: true),
-            .init(wValue: 3, displayName: "Phones R",    pairLabel: "Phones",   isLeft: false),
-            .init(wValue: 4, displayName: "Line Out 5",  pairLabel: "Line 5+6", isLeft: true),
-            .init(wValue: 5, displayName: "Line Out 6",  pairLabel: "Line 5+6", isLeft: false),
+            .init(wValue: 2, displayName: "HP 01 L",     pairLabel: "HP 01",    isLeft: true),
+            .init(wValue: 3, displayName: "HP 01 R",     pairLabel: "HP 01",    isLeft: false),
+            .init(wValue: 4, displayName: "HP 02 L",     pairLabel: "HP 02",    isLeft: true),
+            .init(wValue: 5, displayName: "HP 02 R",     pairLabel: "HP 02",    isLeft: false),
             .init(wValue: 6, displayName: "S/PDIF L",    pairLabel: "S/PDIF",   isLeft: true),
             .init(wValue: 7, displayName: "S/PDIF R",    pairLabel: "S/PDIF",   isLeft: false),
         ],

--- a/Sources/ScarlettCore/DeviceProfile.swift
+++ b/Sources/ScarlettCore/DeviceProfile.swift
@@ -32,6 +32,11 @@ public struct DeviceProfile: Sendable, Equatable {
     public let internalName: String
     /// Marketing name shown to users.
     public let displayName: String
+    /// `displayName` without the trailing " (1st gen)" marker — used where
+    /// the generation is spelled out separately in the UI.
+    public var shortDisplayName: String {
+        displayName.replacingOccurrences(of: " (1st gen)", with: "")
+    }
     /// True for everything we've not personally validated on hardware.
     public let isExperimental: Bool
 


### PR DESCRIPTION
A follow-up of my [previous, stale, 18i8 support PR](https://github.com/MarecekW/scarlett-mixcontrol-1stgen/pull/4). This one has some slight updates to help "enhance" the UX when using an 18i8. 

Feel free to split this up if you only want part of the below feature set.

### Changes

When applied, this PR will:

* Split the matrix mixer into two compact rows with halved strip heights,
  so all 18 inputs of the 18i8 (and 8-bus devices) fit comfortably on screen
* Auto-pan stereo pairs hard left/right when linking and center when
  unlinking, mirroring Focusrite MixControl behaviour. Linked partner pan
  also mirrors in real time during drag.
* Auto-backup snapshots before reset (default on)
  * add on-quit and on-launch options
* Add a profile-driven Default preset row with a blue Reset button for
  quick factory reset
* Allow inline rename of saved presets
* Fix Scarlett 18i8 physical output naming: HP 01 and HP 02 for the two front headphone jacks instead of Phones and Line Out 5/6
* Drop the duplicate "(1st gen)" suffix in the sidebar headline since the
  subtitle already says "1st Gen"

### Screenshots
<img width="1721" height="707" alt="Screenshot 2026-07-15 at 9 36 38 PM" src="https://github.com/user-attachments/assets/b2304d6d-79fe-4171-924a-fe9b324b14ad" />
<img width="766" height="347" alt="Screenshot 2026-07-15 at 9 36 49 PM" src="https://github.com/user-attachments/assets/76847c6e-a8d8-4654-bb27-ae0c386c69b5" />
<img width="831" height="484" alt="Presets" src="https://github.com/user-attachments/assets/f0ed8430-9747-4c5d-86cf-b02011de9471" />



### Note
* Tested only on macOS 26 with a Scarlett 18i8
  * Please verify this didn't break 8i6 support or the UI on your end
* Drive-by PR. Seems to do the trick, but I'm not well-versed in Swift
  and won't be able to support this long-term.